### PR TITLE
Fix monitor leaving stale rows when switching between differently-sized sessions

### DIFF
--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -343,6 +343,12 @@ fn draw_frame(
             let dashes = "─".repeat(frame_width.saturating_sub(2));
             write!(out, "\x1b[{row};1H\x1b[2K\x1b[90m└{dashes}┘\x1b[0m",)?;
         }
+        row += 1;
+    }
+
+    // Clear any remaining rows below the frame
+    if row <= term_rows {
+        write!(out, "\x1b[{row};1H\x1b[J")?;
     }
 
     out.flush()?;


### PR DESCRIPTION
Closes #8

## Summary

- After rendering the frame in `draw_frame()`, clear from the last drawn row to the end of the screen using `\x1b[J` (Erase in Display)
- This removes stale content left by previously displayed larger sessions when switching to a smaller one

## Test plan

- [ ] `cargo test` passes (all 10 tests)
- [ ] `tu run --name big --rows 40 -- bash && tu run --name small --rows 10 -- bash && tu monitor` — switching between sessions with arrow keys should show a clean display with no leftover rows from the bigger session