### PR TITLE
Drop stale COLUMNS/LINES env vars on spawn

### DIFF
--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -113,12 +113,10 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
         // Check keys every 100ms (responsive input)
         match tty.read_key(Duration::from_millis(100))? {
             Some(Key::Quit) => break,
-            Some(Key::Left) => {
-                if *current_idx > 0 {
-                    *current_idx -= 1;
-                    last_rows = None;
-                    last_fetch = std::time::Instant::now() - fetch_interval; // force refetch
-                }
+            Some(Key::Left) if *current_idx > 0 => {
+                *current_idx -= 1;
+                last_rows = None;
+                last_fetch = std::time::Instant::now() - fetch_interval; // force refetch
             }
             Some(Key::Right) => {
                 let sessions = get_session_names().await.unwrap_or_default();
@@ -128,7 +126,7 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
                     last_fetch = std::time::Instant::now() - fetch_interval;
                 }
             }
-            None => {}
+            Some(Key::Left) | None => {}
         }
     }
 

--- a/src/pty/spawn.rs
+++ b/src/pty/spawn.rs
@@ -72,10 +72,16 @@ pub fn spawn(
                 let _ = close(slave_raw);
             }
 
-            // Set environment
+            // Set environment. Do NOT set COLUMNS/LINES: they're only ever
+            // correct at spawn-time and never update on resize. Libraries like
+            // Python's shutil.get_terminal_size() read these env vars first and
+            // fall back to TIOCGWINSZ only if unset, so leaving stale values
+            // here causes those libraries (and anything that uses them, e.g.
+            // Textual) to report the wrong size forever. TIOCGWINSZ is
+            // authoritative and always current.
             std::env::set_var("TERM", term);
-            std::env::set_var("COLUMNS", size.cols.to_string());
-            std::env::set_var("LINES", size.rows.to_string());
+            std::env::remove_var("COLUMNS");
+            std::env::remove_var("LINES");
             for (key, value) in env {
                 std::env::set_var(key, value);
             }


### PR DESCRIPTION
## Summary

Closes #13. `tu` pre-seeds `COLUMNS` and `LINES` env vars when spawning child processes. These are set once at spawn time and never updated on resize, so any child code that consults them before falling back to `TIOCGWINSZ` (most notably Python's `shutil.get_terminal_size()`) sees a stale size forever — even though `SIGWINCH` fires correctly and the PTY's winsize IS updated.

This stops Textual apps (and anything else built on `shutil`) from repainting on `tu resize`.

## Change

Remove the `std::env::set_var("COLUMNS", …)` / `LINES` calls in `src/pty/spawn.rs`; actively `remove_var` them instead so they don't leak in from the tu daemon's own env.

`TIOCGWINSZ` on the slave PTY is always authoritative and child processes can query it at any time.

## Test plan

Minimal repro — with `tu` built from `main`:
```
shutil=120x40  os=120x40  ioctl=120x40      ← spawn
[WINCH] shutil=120x40  os=200x60  ioctl=200x60  ← resize: shutil is STALE
```

With this PR applied:
```
shutil=120x40  os=120x40  ioctl=120x40
[WINCH] shutil=200x60  os=200x60  ioctl=200x60  ← all agree
```

Verified end-to-end by running [forestui](https://github.com/flipbit03/forestui) (a Textual TUI) inside `tu run` and confirming it correctly repaints at 120x40 → 200x60 → 100x30 → 180x50. Also confirmed `bash`, `mc`, and other ioctl-based tools continue to work (they never read these env vars in the first place).