### PR TITLE
Mouse input + alacritty_terminal: tu becomes a full-blown terminal emulator for agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,17 +15,19 @@ RUSTDOCFLAGS="-Dwarnings" cargo doc --all-features --no-deps  # doc lint (CI enf
 
 ## Architecture
 
-CLI client → Unix socket (JSON-over-newline) → background daemon → per-session PTY + vt100 emulator.
+CLI client → Unix socket (JSON-over-newline) → background daemon → per-session PTY + alacritty_terminal emulator.
 
 - `src/main.rs` — clap CLI, command dispatch
-- `src/daemon/server.rs` — Unix socket listener, daemon lifecycle
-- `src/daemon/session.rs` — PTY + vt100 per terminal session
-- `src/daemon/manager.rs` — session map, request handling
-- `src/daemon/protocol.rs` — JSON request/response types
-- `src/pty/` — PTY spawn, input injection, resize
+- `src/daemon/server.rs` — Unix socket listener, daemon lifecycle. `Wait` and `Mouse` requests run outside the manager lock so they don't block `monitor` polls.
+- `src/daemon/session.rs` — PTY + emulator per session, plus a per-session `MouseTracker` (synthetic cursor, held buttons, last event)
+- `src/daemon/manager.rs` — session map, request handling, `handle_mouse_glided` (interpolated mouse motion)
+- `src/daemon/protocol.rs` — JSON request/response types, mouse action/target/state types
+- `src/emu.rs` — wrapper around `alacritty_terminal` + its embedded `vte::ansi` parser; exposes the small Parser/Screen/Cell/Color slice the rest of the codebase consumes. Capture proxy queues `Event::PtyWrite` replies (DA, DCS, etc.) for the reader to forward back to the PTY.
+- `src/pty/` — PTY spawn (ECHOCTL off so curses subshell apps see clean ESC echo), input injection, resize
 - `src/keys.rs` — key name → escape sequence mapping
+- `src/mouse.rs` — wire encoders for SGR / Default / UTF-8 mouse protocols, screen-search helpers (`find_text` / `find_regex`)
 - `src/commands/` — CLI command handlers (each talks to daemon)
-- `src/render/` — text and image screenshot renderers
+- `src/render/` — text and image screenshot renderers (PNG paints a magenta `△` cursor overlay)
 
 ## Conventions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2052,7 +2052,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "vte",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2097,9 +2097,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "untrusted"
@@ -2144,35 +2144,23 @@ dependencies = [
 
 [[package]]
 name = "vt100"
-version = "0.15.2"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cd863bf0db7e392ba3bd04994be3473491b31e66340672af5d11943c6274de"
+checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
 dependencies = [
  "itoa",
- "log",
  "unicode-width",
  "vte",
 ]
 
 [[package]]
 name = "vte"
-version = "0.11.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
 dependencies = [
  "arrayvec",
- "utf8parse",
- "vte_generate_state_changes",
-]
-
-[[package]]
-name = "vte_generate_state_changes"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
-dependencies = [
- "proc-macro2",
- "quote",
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "alacritty_terminal"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda177466b9524d59f1b12f0dd30b68696788e9992a7e959021c4a0ed96fcf59"
+dependencies = [
+ "base64",
+ "bitflags",
+ "home",
+ "libc",
+ "log",
+ "miow",
+ "parking_lot",
+ "piper",
+ "polling",
+ "regex-automata",
+ "rustix",
+ "rustix-openpty",
+ "serde",
+ "signal-hook",
+ "unicode-width",
+ "vte",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "aligned"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +245,9 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitstream-io"
@@ -337,6 +365,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +421,12 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "displaydoc"
@@ -446,6 +489,12 @@ dependencies = [
  "smallvec",
  "zune-inflate",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
@@ -515,6 +564,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-task"
@@ -587,6 +642,21 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -956,6 +1026,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,6 +1111,15 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "miow"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -1256,6 +1341,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,6 +1362,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1653,6 +1763,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-openpty"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de16c7c59892b870a6336f185dc10943517f1327447096bbb7bb32cd85e2393"
+dependencies = [
+ "errno",
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,6 +1916,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1895,6 +2039,7 @@ name = "terminal-use"
 version = "0.0.0"
 dependencies = [
  "ab_glyph",
+ "alacritty_terminal",
  "anyhow",
  "base64",
  "clap",
@@ -1907,7 +2052,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "vt100",
+ "vte",
 ]
 
 [[package]]
@@ -2143,24 +2288,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "vt100"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
-dependencies = [
- "itoa",
- "unicode-width",
- "vte",
-]
-
-[[package]]
 name = "vte"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
 dependencies = [
  "arrayvec",
+ "bitflags",
+ "cursor-icon",
+ "log",
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -2298,6 +2436,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ clap = { version = "4", features = ["derive"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 imageproc = "0.25"
 nix = { version = "0.31", features = ["term", "signal", "process", "ioctl", "fs", "user", "poll"] }
-vt100 = "0.15"
+vt100 = "0.16"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 imageproc = "0.25"
 nix = { version = "0.31", features = ["term", "signal", "process", "ioctl", "fs", "user", "poll"] }
 alacritty_terminal = "0.26"
-vte = "0.15"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ clap = { version = "4", features = ["derive"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 imageproc = "0.25"
 nix = { version = "0.31", features = ["term", "signal", "process", "ioctl", "fs", "user", "poll"] }
-vt100 = "0.16"
+alacritty_terminal = "0.26"
+vte = "0.15"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://github.com/user-attachments/assets/8dd87972-2ef5-4104-9074-52b6ee528e08
 A real terminal emulator: anything that runs in your real terminal runs in `tu`.
 
 - **Curses / TUI apps**: vim, less, htop, mc, top, nano, lazygit, tig, ranger.
-- **Modern shell integration**: OSC 133 semantic prompts, OSC 7 working-directory hints, OSC 8 hyperlinks, APC, focus-event reporting — all consumed silently instead of leaking into the output as `^[…` artifacts.
+- **Modern shell integration**: OSC 133 semantic prompts, OSC 7 working-directory hints, OSC 8 hyperlinks, APC, focus-event reporting.
 - **Terminal queries**: DA / DCS terminfo / DECRQSS replies are answered automatically, so curses apps don't hang on startup waiting for terminal capability responses.
 - **Mouse**: synthetic mouse input (click, drag, move, scroll), text-based targeting (`--on-text`, `--on-regex`), modifier keys, multi-click. Cursor glides between positions for real-mouse motion semantics.
 - **Live monitor**: 30 fps read-only view with diff-based emission — fluid over SSH.
@@ -110,8 +110,8 @@ tu CLI --> Unix socket (JSON) --> daemon --> PTY + alacritty_terminal
                                           fed back to the inner app
 ```
 
-- The emulator is alacritty's. It handles the full xterm command set including modern shell-integration sequences. Unknown / unsupported escapes are consumed cleanly rather than leaking into cell content.
-- Replies the terminal owes the inner app (Device Attributes, cursor reports, DCS terminfo queries) are forwarded to the PTY via a writeback path — so vim, less, mc and friends boot without hanging.
+- The emulator is alacritty's. It handles the full xterm command set, including modern shell-integration sequences.
+- When the inner app queries terminal capabilities (Device Attributes, cursor reports, terminfo lookups), `tu` answers — so vim, less, mc and friends don't hang on startup waiting for a reply.
 - The daemon auto-starts on first use and auto-exits after 8 hours of inactivity.
 
 ## Defaults

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ tu self update
 
 ## Add to your agent
 
-Add the following block of text to your `CLAUDE.md`/`AGENTS.md` (or similar) to inform your agent of the existence of `tu`:
+Add the following block to your `CLAUDE.md`/`AGENTS.md` (or similar) to inform your agent of the existence of `tu`:
 
 ```
 # terminal-use (`tu`)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ tu self update
 
 ## Add to your agent
 
+Add the following block of text to your `CLAUDE.md`/`AGENTS.md` (or similar) to inform your agent of the existence of `tu`:
+
 ```
 # terminal-use (`tu`)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # terminal-use (`tu`)
 
-Headless virtual terminal for AI agents. Spawn interactive terminal apps, read the screen, drive keyboard *and* mouse. No GUI, no X server, no display needed.
+`tu` is a full blown terminal emulator for AI agents. 
+
+Spawn interactive terminal apps, read the screen, drive the keyboard *and* mouse. No GUI, no X server, no display needed.
 
 `tu` is to terminal applications what [agent-browser](https://github.com/vercel-labs/agent-browser) is to web pages.
 
@@ -17,7 +19,7 @@ A real terminal emulator: anything that runs in your real terminal runs in `tu`.
 - **Curses / TUI apps**: vim, less, htop, mc, top, nano, lazygit, tig, ranger.
 - **Modern shell integration**: OSC 133 semantic prompts, OSC 7 working-directory hints, OSC 8 hyperlinks, APC, focus-event reporting.
 - **Terminal queries**: DA / DCS terminfo / DECRQSS replies are answered automatically, so curses apps don't hang on startup waiting for terminal capability responses.
-- **Mouse**: synthetic mouse input (click, drag, move, scroll), text-based targeting (`--on-text`, `--on-regex`), modifier keys, multi-click. Cursor glides between positions for real-mouse motion semantics.
+- **Mouse**: virtual mouse input (click, drag, move, scroll), text-based targeting (`--on-text`, `--on-regex`), modifier keys, multi-click. The virtual cursor glides between positions before each click for real-mouse motion semantics.
 - **Live monitor**: 30 fps read-only view with diff-based emission — fluid over SSH.
 
 ## Install
@@ -76,7 +78,7 @@ tu mouse click --on-text "Buy" --clicks 2          # double-click a label
 tu mouse drag 10 10 50 30                          # drag from → to
 tu mouse scroll down --amount 5
 
-# Inspect mouse state (mode, encoding, synthetic cursor, held buttons)
+# Inspect mouse state (mode, virtual cursor, held buttons)
 tu mouse state
 
 # Wait for screen state
@@ -94,7 +96,7 @@ tu monitor --name nethack         # Watch a specific session
 
 - Full-color terminal rendering inside a framed window
 - 30 fps refresh, diff-based emit — minimal bandwidth on SSH
-- Shows the synthetic mouse cursor as a magenta `△` (filled when a button is held)
+- Shows the virtual mouse cursor as a magenta `△` (filled when a button is held)
 - Left/Right arrows to switch between sessions
 - Handles terminal resize
 - Ctrl+C to detach

--- a/README.md
+++ b/README.md
@@ -12,31 +12,29 @@ An AI agent playing NetHack — character creation, dungeon exploration, combat 
 
 https://github.com/user-attachments/assets/8dd87972-2ef5-4104-9074-52b6ee528e08
 
-## What works
+## Features
 
-A real terminal emulator: anything that runs in your real terminal runs in `tu`.
-
-- **Curses / TUI apps**: vim, less, htop, mc, top, nano, lazygit, tig, ranger.
-- **Modern shell integration**: OSC 133 semantic prompts, OSC 7 working-directory hints, OSC 8 hyperlinks, APC, focus-event reporting.
-- **Terminal queries**: DA / DCS terminfo / DECRQSS replies are answered automatically, so curses apps don't hang on startup waiting for terminal capability responses.
-- **Mouse**: virtual mouse input (click, drag, move, scroll), text-based targeting (`--on-text`, `--on-regex`), modifier keys, multi-click. The virtual cursor glides between positions before each click for real-mouse motion semantics.
-- **Live monitor**: 30 fps read-only view with diff-based emission — fluid over SSH.
+- **Screen reads**: text or PNG screenshots of the rendered terminal.
+- **Keyboard**: type text, send named keys (`Enter`, `F5`, `Ctrl+C`).
+- **Mouse**: click, drag, move, scroll. Find buttons by their label instead of pixel-hunting for coords.
+- **Wait**: block until a regex matches the screen or the screen stops changing.
+- **Sessions**: multiple terminals at once. It's basically `tmux` for your agent.
+- **Live monitor**: Want to visually check what your agent is seeing? Check the [tu monitor](#tu-monitor) command.
 
 ## Install
 
-Prebuilt binary (Linux, macOS):
-
+Prebuilt binaries available for Linux (x86_64/ARM) and macOS (ARM). One click installer, no Rust tooling needed:
 ```bash
 curl -fsSL https://raw.githubusercontent.com/flipbit03/terminal-use/main/install.sh | sh
 ```
 
-From source:
+Or compiled directly in your box, from source:
 
 ```bash
 cargo install terminal-use
 ```
 
-To update:
+To update `tu` to the latest version (regardless of the installation method):
 
 ```bash
 tu self update
@@ -95,21 +93,31 @@ tu monitor --name nethack         # Watch a specific session
 ```
 
 - Full-color terminal rendering inside a framed window
-- 30 fps refresh, diff-based emit — minimal bandwidth on SSH
-- Shows the virtual mouse cursor as a magenta `△` (filled when a button is held)
-- Left/Right arrows to switch between sessions
+- 30 fps refresh, diff-based emit — uses minimal bandwidth / efficient on SSH
+- Shows the virtual mouse cursor (if active) as a magenta `△` (filled when a button is held)
+- Left/Right arrows to switch between multiple sessions
 - Handles terminal resize
 - Ctrl+C to detach
 
 ## How it works
 
-`tu` wraps a headless PTY + [`alacritty_terminal`](https://crates.io/crates/alacritty_terminal) emulator behind a CLI. A background daemon manages sessions — each CLI invocation is stateless.
+`tu` wraps a headless PTY + [`alacritty_terminal`](https://crates.io/crates/alacritty_terminal) emulator behind a CLI. A background daemon manages sessions — each CLI invocation is stateless. The agent driving things and the human watching share the same daemon:
 
-```
-tu CLI --> Unix socket (JSON) --> daemon --> PTY + alacritty_terminal
-                                                      ↑
-                                          replies (DA, DCS, …)
-                                          fed back to the inner app
+```mermaid
+flowchart LR
+    Agent["🤖 Agent<br/>(LLM)"] -->|"tu run · mouse · type · screenshot · wait …"| CLI["tu CLI<br/>(stateless, one-shot)"]
+    Human["👤 Human<br/>(you)"] -->|"tu monitor"| Mon["tu monitor<br/>(long-running viewer)"]
+
+    CLI <-->|"JSON · Unix socket"| Daemon
+    Mon <-.->|"JSON · Unix socket<br/>(read-only, ~30fps)"| Daemon
+
+    subgraph Daemon["tu daemon (auto-spawned, idle 8h)"]
+        Sessions["session map"]
+        Emu["alacritty_terminal<br/>+ mouse trackers"]
+        Sessions --- Emu
+    end
+
+    Daemon <-->|"PTY master fd"| App["Inner app<br/>vim · mc · htop · …"]
 ```
 
 - The emulator is alacritty's. It handles the full xterm command set, including modern shell-integration sequences.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terminal-use (`tu`)
 
-Headless virtual terminal for AI agents. Spawn interactive terminal apps, read the screen, send keystrokes. No GUI, no X server, no display needed.
+Headless virtual terminal for AI agents. Spawn interactive terminal apps, read the screen, drive keyboard *and* mouse. No GUI, no X server, no display needed.
 
 `tu` is to terminal applications what [agent-browser](https://github.com/vercel-labs/agent-browser) is to web pages.
 
@@ -9,6 +9,16 @@ Headless virtual terminal for AI agents. Spawn interactive terminal apps, read t
 An AI agent playing NetHack — character creation, dungeon exploration, combat — driven entirely through `tu`:
 
 https://github.com/user-attachments/assets/8dd87972-2ef5-4104-9074-52b6ee528e08
+
+## What works
+
+A real terminal emulator: anything that runs in your real terminal runs in `tu`.
+
+- **Curses / TUI apps**: vim, less, htop, mc, top, nano, lazygit, tig, ranger.
+- **Modern shell integration**: OSC 133 semantic prompts, OSC 7 working-directory hints, OSC 8 hyperlinks, APC, focus-event reporting — all consumed silently instead of leaking into the output as `^[…` artifacts.
+- **Terminal queries**: DA / DCS terminfo / DECRQSS replies are answered automatically, so curses apps don't hang on startup waiting for terminal capability responses.
+- **Mouse**: synthetic mouse input (click, drag, move, scroll), text-based targeting (`--on-text`, `--on-regex`), modifier keys, multi-click. Cursor glides between positions for real-mouse motion semantics.
+- **Live monitor**: 30 fps read-only view with diff-based emission — fluid over SSH.
 
 ## Install
 
@@ -35,13 +45,43 @@ tu self update
 ```
 # terminal-use (`tu`)
 
-Some programs (htop, vim, mc, dialog-based installers, ncurses UIs) need a real
-terminal to render their interface — you can't just pipe stdin/stdout. Use `tu`
-to run them in a virtual terminal, screenshot the screen and send keystrokes.
-Run `tu usage` before the first interaction for the full command reference.
+Some programs (htop, vim, mc, dialog-based installers, ncurses UIs) need a
+real terminal to render their interface — you can't just pipe stdin/stdout.
+Use `tu` to run them in a virtual terminal, screenshot the screen, send
+keystrokes, and drive the mouse. Run `tu usage` before the first
+interaction for the full command reference.
 ```
 
 That's it!
+
+## Quick taste
+
+```bash
+# Spawn an app
+tu run htop
+
+# Read what's on screen (text or PNG)
+tu screenshot
+tu screenshot --png -o shot.png
+
+# Send keystrokes
+tu press F2                     # F2
+tu press Escape : w q Enter     # save + quit vim
+tu type "hello world"
+
+# Drive the mouse — by coords, or by what's on screen
+tu mouse click 50 20
+tu mouse click --on-text "OK"
+tu mouse click --on-text "Buy" --clicks 2          # double-click a label
+tu mouse drag 10 10 50 30                          # drag from → to
+tu mouse scroll down --amount 5
+
+# Inspect mouse state (mode, encoding, synthetic cursor, held buttons)
+tu mouse state
+
+# Wait for screen state
+tu wait --text "Complete" --timeout 10000
+```
 
 ## `tu monitor`
 
@@ -53,19 +93,26 @@ tu monitor --name nethack         # Watch a specific session
 ```
 
 - Full-color terminal rendering inside a framed window
+- 30 fps refresh, diff-based emit — minimal bandwidth on SSH
+- Shows the synthetic mouse cursor as a magenta `△` (filled when a button is held)
 - Left/Right arrows to switch between sessions
 - Handles terminal resize
 - Ctrl+C to detach
 
 ## How it works
 
-`tu` wraps a headless PTY + [vt100](https://crates.io/crates/vt100) terminal emulator behind a CLI. A background daemon manages sessions — each CLI invocation is stateless.
+`tu` wraps a headless PTY + [`alacritty_terminal`](https://crates.io/crates/alacritty_terminal) emulator behind a CLI. A background daemon manages sessions — each CLI invocation is stateless.
 
 ```
-tu CLI --> Unix socket (JSON) --> daemon --> PTY + vt100 emulator
+tu CLI --> Unix socket (JSON) --> daemon --> PTY + alacritty_terminal
+                                                      ↑
+                                          replies (DA, DCS, …)
+                                          fed back to the inner app
 ```
 
-The daemon auto-starts on first use and auto-exits after 8 hours of inactivity.
+- The emulator is alacritty's. It handles the full xterm command set including modern shell-integration sequences. Unknown / unsupported escapes are consumed cleanly rather than leaking into cell content.
+- Replies the terminal owes the inner app (Device Attributes, cursor reports, DCS terminfo queries) are forwarded to the PTY via a writeback path — so vim, less, mc and friends boot without hanging.
+- The daemon auto-starts on first use and auto-exits after 8 hours of inactivity.
 
 ## Defaults
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod daemon_cmd;
 pub mod kill;
 pub mod list;
 pub mod monitor;
+pub mod mouse;
 pub mod paste;
 pub mod press;
 pub mod resize;

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 
-use crate::daemon::protocol::{Request, Response};
+use crate::daemon::protocol::{CursorPos, Request, Response};
 use crate::daemon::server::{ensure_daemon, send_request};
 
 /// Run the attach live viewer.
@@ -41,13 +41,18 @@ pub async fn run(initial_name: String) -> Result<()> {
     result
 }
 
+/// Frame interval for the live monitor. ~30fps; chosen high enough to feel
+/// fluid for drag/scroll visualization but not so high that we burn CPU.
+/// Monitor sessions are interactive and short-lived, so the extra work is fine.
+const FRAME_INTERVAL_MS: u64 = 33;
+
 async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> {
     let mut last_rows: Option<Vec<String>> = None;
     let mut last_term_size = get_terminal_size();
     let mut last_fetch = std::time::Instant::now() - Duration::from_secs(10); // force immediate first fetch
     let mut last_change = std::time::Instant::now();
 
-    let fetch_interval = Duration::from_millis(500);
+    let fetch_interval = Duration::from_millis(FRAME_INTERVAL_MS);
 
     loop {
         // Detect terminal resize → clear screen + force redraw
@@ -59,14 +64,14 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
             last_fetch = std::time::Instant::now() - fetch_interval; // force refetch
         }
 
-        // Fetch screen from daemon every ~500ms
+        // Fetch + redraw at ~30fps.
         if last_fetch.elapsed() >= fetch_interval {
             last_fetch = std::time::Instant::now();
 
             let sessions = get_session_names().await.unwrap_or_default();
             if sessions.is_empty() {
                 draw_waiting_screen()?;
-                match tty.read_key(Duration::from_millis(250))? {
+                match tty.read_key(Duration::from_millis(FRAME_INTERVAL_MS))? {
                     Some(Key::Quit) => break,
                     _ => continue,
                 }
@@ -86,6 +91,8 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
                     rows_ansi,
                     rows,
                     cols,
+                    mouse_cursor,
+                    mouse_held,
                 }) => {
                     let changed = last_rows.as_ref() != Some(&rows_ansi);
                     if changed {
@@ -101,6 +108,8 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
                         cols,
                         term_size,
                         last_change.elapsed(),
+                        mouse_cursor,
+                        mouse_held,
                     )?;
                 }
                 Ok(Response::Error { message: _ }) => {
@@ -110,8 +119,9 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
             }
         }
 
-        // Check keys every 100ms (responsive input)
-        match tty.read_key(Duration::from_millis(100))? {
+        // Poll keys with a short timeout so the frame loop stays responsive.
+        // The wake-up effectively caps redraws at FRAME_INTERVAL_MS.
+        match tty.read_key(Duration::from_millis(FRAME_INTERVAL_MS))? {
             Some(Key::Quit) => break,
             Some(Key::Left) if *current_idx > 0 => {
                 *current_idx -= 1;
@@ -222,6 +232,7 @@ fn format_elapsed(d: Duration) -> String {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn draw_frame(
     sessions: &[String],
     active_idx: usize,
@@ -230,6 +241,8 @@ fn draw_frame(
     sess_cols: u16,
     term_size: (u16, u16),
     since_last_change: Duration,
+    mouse_cursor: Option<CursorPos>,
+    mouse_held: bool,
 ) -> Result<()> {
     let (term_cols, term_rows) = term_size;
     let mut out = io::stdout().lock();
@@ -349,8 +362,45 @@ fn draw_frame(
         write!(out, "\x1b[{row};1H\x1b[J")?;
     }
 
+    // Synthetic mouse cursor overlay: tu's last-known position lives outside
+    // any application's rendering, so we paint it on top after the inner app's
+    // own output.
+    if let Some(cursor) = mouse_cursor {
+        if cursor.col < sess_cols && cursor.row < sess_rows {
+            // Layout: status(1) + [tabs(1)] + top border(1) + content rows
+            let header_rows: u16 = if sessions.len() > 1 { 3 } else { 2 };
+            let content_first = header_rows + 1; // content[0] sits one row past the header rows
+            let term_row = content_first + cursor.row;
+            // Frame's left border occupies column 1; content starts at column 2.
+            let term_col = 2 + cursor.col;
+            // Stay inside the visible area (avoid drawing on or past the
+            // bottom-fade ellipsis or right-clip rules).
+            let max_content_row = (header_rows + sess_rows).min(term_rows);
+            let max_visible_col = if term_cols >= 2 { term_cols - 1 } else { 0 };
+            if term_row <= max_content_row && term_col <= max_visible_col + 1 {
+                let body = mouse_cursor_glyph(mouse_held);
+                write!(out, "\x1b[{term_row};{term_col}H{body}\x1b[0m")?;
+            }
+        }
+    }
+
     out.flush()?;
     Ok(())
+}
+
+/// SGR-wrapped single-cell glyph for the synthetic mouse cursor.
+///
+/// The colour is bright magenta (chosen to be uncommon in TUIs so it doesn't
+/// blend in). Held = filled block; idle = outline so the underlying cell
+/// stays partially readable.
+fn mouse_cursor_glyph(held: bool) -> &'static str {
+    if held {
+        // Bright magenta bg + bright white fg + bold + filled block.
+        "\x1b[1;48;5;201;97m█"
+    } else {
+        // Bright magenta fg, bold, hollow box. Underlying cell colour stays.
+        "\x1b[1;38;5;201m▢"
+    }
 }
 
 fn build_tab_bar(sessions: &[String], active_idx: usize) -> String {

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 
-use crate::daemon::protocol::{Request, Response};
+use crate::daemon::protocol::{CursorPos, Request, Response};
 use crate::daemon::server::{ensure_daemon, send_request};
 
 /// Run the attach live viewer.
@@ -51,6 +51,11 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
     let mut last_term_size = get_terminal_size();
     let mut last_fetch = std::time::Instant::now() - Duration::from_secs(10); // force immediate first fetch
     let mut last_change = std::time::Instant::now();
+    // Diff state: the previously-emitted frame as a vector of one ANSI string per
+    // visible terminal row. Each new frame is rendered into a fresh `Vec<String>`
+    // and compared row-by-row; only changed rows are written to stdout. This is
+    // the bulk of the flicker fix — most rows stay byte-identical between frames.
+    let mut prev_frame: Option<Vec<String>> = None;
 
     let fetch_interval = Duration::from_millis(FRAME_INTERVAL_MS);
 
@@ -61,6 +66,7 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
             print!("\x1b[2J");
             last_term_size = term_size;
             last_rows = None;
+            prev_frame = None;
             last_fetch = std::time::Instant::now() - fetch_interval; // force refetch
         }
 
@@ -71,6 +77,7 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
             let sessions = get_session_names().await.unwrap_or_default();
             if sessions.is_empty() {
                 draw_waiting_screen()?;
+                prev_frame = None;
                 match tty.read_key(Duration::from_millis(FRAME_INTERVAL_MS))? {
                     Some(Key::Quit) => break,
                     _ => continue,
@@ -91,14 +98,15 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
                     rows_ansi,
                     rows,
                     cols,
+                    mouse_cursor,
+                    mouse_held,
                 }) => {
                     let changed = last_rows.as_ref() != Some(&rows_ansi);
                     if changed {
                         last_change = std::time::Instant::now();
                         last_rows = Some(rows_ansi.clone());
                     }
-                    // Always redraw to update the "last change" timer
-                    draw_frame(
+                    let new_frame = build_frame_strings(
                         &sessions,
                         *current_idx,
                         &rows_ansi,
@@ -106,10 +114,15 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
                         cols,
                         term_size,
                         last_change.elapsed(),
-                    )?;
+                        mouse_cursor,
+                        mouse_held,
+                    );
+                    emit_frame_diff(prev_frame.as_deref(), &new_frame, &sessions[*current_idx])?;
+                    prev_frame = Some(new_frame);
                 }
                 Ok(Response::Error { message: _ }) => {
                     last_rows = None;
+                    prev_frame = None;
                 }
                 _ => {}
             }
@@ -122,6 +135,7 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
             Some(Key::Left) if *current_idx > 0 => {
                 *current_idx -= 1;
                 last_rows = None;
+                prev_frame = None;
                 last_fetch = std::time::Instant::now() - fetch_interval; // force refetch
             }
             Some(Key::Right) => {
@@ -129,6 +143,7 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
                 if *current_idx + 1 < sessions.len() {
                     *current_idx += 1;
                     last_rows = None;
+                    prev_frame = None;
                     last_fetch = std::time::Instant::now() - fetch_interval;
                 }
             }
@@ -228,7 +243,15 @@ fn format_elapsed(d: Duration) -> String {
     }
 }
 
-fn draw_frame(
+/// Render the current frame as a vector of ANSI strings, one per visible
+/// terminal row. Index 0 corresponds to terminal row 1.
+///
+/// The cursor overlay (when set) is appended to the cursor's row string as a
+/// trailing `CSI row;col H <glyph>` sequence. That way the diff naturally
+/// catches cursor movement: when the cursor moves, both the row it left and
+/// the row it entered get re-emitted, but no other rows do.
+#[allow(clippy::too_many_arguments)]
+fn build_frame_strings(
     sessions: &[String],
     active_idx: usize,
     rows_ansi: &[String],
@@ -236,74 +259,57 @@ fn draw_frame(
     sess_cols: u16,
     term_size: (u16, u16),
     since_last_change: Duration,
-) -> Result<()> {
+    mouse_cursor: Option<CursorPos>,
+    mouse_held: bool,
+) -> Vec<String> {
     let (term_cols, term_rows) = term_size;
-    let mut out = io::stdout().lock();
 
     let frame_width = sess_cols as usize + 2;
     let tcols = term_cols as usize;
     let cropped_right = tcols < frame_width;
 
-    // How many content rows can we show?
     // Layout: status(1) + [tab bar(1)] + top border(1) + content + bottom border(1)
-    let header_rows = if sessions.len() > 1 { 3u16 } else { 2u16 }; // status + [tabs] + top border
-    let available_content_rows = term_rows.saturating_sub(header_rows + 1); // +1 for bottom border
-    let content_rows_to_show = (sess_rows).min(available_content_rows);
+    let header_rows = if sessions.len() > 1 { 3u16 } else { 2u16 };
+    let available_content_rows = term_rows.saturating_sub(header_rows + 1);
+    let content_rows_to_show = sess_rows.min(available_content_rows);
     let cropped_bottom = content_rows_to_show < sess_rows;
 
-    // Set terminal window title via OSC
-    write!(out, "\x1b]0;tu monitor: {}\x07", &sessions[active_idx])?;
+    let mut frame: Vec<String> = Vec::with_capacity(term_rows as usize);
 
-    // Move cursor home
-    write!(out, "\x1b[H")?;
-
-    let mut row = 1u16;
-
-    // Row 1: status bar (always visible, pinned to top)
+    // Row 1: status bar
     let elapsed = format_elapsed(since_last_change);
     let status = if sessions.len() > 1 {
         format!("terminal-use monitor · last change {elapsed} · ← → switch · Ctrl+C detach")
     } else {
         format!("terminal-use monitor · last change {elapsed} · Ctrl+C detach")
     };
-    write!(out, "\x1b[{row};1H\x1b[2K\x1b[90m{status}\x1b[0m")?;
-    row += 1;
+    frame.push(format!("\x1b[90m{status}\x1b[0m"));
 
-    // Tab bar (only if multiple sessions)
-    if sessions.len() > 1 && row <= term_rows {
-        let tab_bar = build_tab_bar(sessions, active_idx);
-        write!(out, "\x1b[{row};1H\x1b[2K{tab_bar}")?;
-        row += 1;
+    // Tab bar
+    if sessions.len() > 1 {
+        frame.push(build_tab_bar(sessions, active_idx));
     }
 
-    // Top border: ┌─ name [COLSxROWS] ─...─┐
-    if row <= term_rows {
+    // Top border
+    {
         let title = format!(" {} [{}x{}] ", &sessions[active_idx], sess_cols, sess_rows);
-        let prefix_width = 2 + title.len(); // ┌─ + title
-        if cropped_right {
-            // Dashes fill up to tcols, last 3 chars become ···
+        let prefix_width = 2 + title.len();
+        let line = if cropped_right {
             let dash_space = tcols.saturating_sub(prefix_width);
             let (dashes, suffix) = if dash_space > 3 {
                 ("─".repeat(dash_space - 3), "···")
             } else {
                 ("─".repeat(dash_space), "")
             };
-            write!(
-                out,
-                "\x1b[{row};1H\x1b[2K\x1b[90m┌─\x1b[0m\x1b[1m{title}\x1b[0m\x1b[90m{dashes}{suffix}\x1b[0m",
-            )?;
+            format!("\x1b[90m┌─\x1b[0m\x1b[1m{title}\x1b[0m\x1b[90m{dashes}{suffix}\x1b[0m")
         } else {
             let dashes = "─".repeat(frame_width.saturating_sub(prefix_width + 1));
-            write!(
-                out,
-                "\x1b[{row};1H\x1b[2K\x1b[90m┌─\x1b[0m\x1b[1m{title}\x1b[0m\x1b[90m{dashes}┐\x1b[0m",
-            )?;
-        }
-        row += 1;
+            format!("\x1b[90m┌─\x1b[0m\x1b[1m{title}\x1b[0m\x1b[90m{dashes}┐\x1b[0m")
+        };
+        frame.push(line);
     }
 
-    // Content rows: │ <row content> │
-    // When cropped bottom, last 3 visible rows get · instead of │ as left border
+    // Content rows
     let fade_start = if cropped_bottom {
         content_rows_to_show.saturating_sub(3) as usize
     } else {
@@ -311,50 +317,103 @@ fn draw_frame(
     };
 
     for r in 0..content_rows_to_show as usize {
-        if row > term_rows {
-            break;
-        }
         let line = rows_ansi.get(r).map(|s| s.as_str()).unwrap_or("");
         let left_border = if r >= fade_start { "·" } else { "│" };
 
-        if !cropped_right {
-            let right_border = if r >= fade_start { "·" } else { "│" };
-            write!(
-                out,
-                "\x1b[{row};1H\x1b[2K\x1b[90m{left_border}\x1b[0m{line}\x1b[0m\x1b[{col}G\x1b[90m{right_border}\x1b[0m",
-                col = frame_width,
-            )?;
+        let mut row_str = if cropped_right {
+            format!("\x1b[90m{left_border}\x1b[0m{line}\x1b[0m")
         } else {
-            write!(
-                out,
-                "\x1b[{row};1H\x1b[2K\x1b[90m{left_border}\x1b[0m{line}\x1b[0m",
-            )?;
+            let right_border = if r >= fade_start { "·" } else { "│" };
+            format!(
+                "\x1b[90m{left_border}\x1b[0m{line}\x1b[0m\x1b[{col}G\x1b[90m{right_border}\x1b[0m",
+                col = frame_width,
+            )
+        };
+
+        // Cursor overlay: appended as a position-and-paint trailer, so the
+        // diff naturally re-emits this row when the cursor moves on/off it
+        // and skips it when the cursor stays put.
+        if let Some(cursor) = mouse_cursor {
+            if cursor.row as usize == r && cursor.col < sess_cols {
+                let term_row = frame.len() as u16 + 1; // 1-indexed terminal row
+                let term_col = 2 + cursor.col; // left border = col 1; content starts at col 2
+                let max_col = if term_cols >= 2 { term_cols } else { 1 };
+                if term_col <= max_col {
+                    row_str.push_str(&format!(
+                        "\x1b[{term_row};{term_col}H{}\x1b[0m",
+                        mouse_cursor_glyph(mouse_held)
+                    ));
+                }
+            }
         }
-        row += 1;
+
+        frame.push(row_str);
     }
 
-    // Bottom border: └─...─┘ (only if not cropped bottom)
-    if !cropped_bottom && row <= term_rows {
-        if cropped_right {
-            let dash_space = tcols.saturating_sub(1); // └ takes 1
+    // Bottom border (only if not cropped bottom)
+    if !cropped_bottom {
+        let line = if cropped_right {
+            let dash_space = tcols.saturating_sub(1);
             let (dashes, suffix) = if dash_space > 3 {
                 ("─".repeat(dash_space - 3), "···")
             } else {
                 ("─".repeat(dash_space), "")
             };
-            write!(out, "\x1b[{row};1H\x1b[2K\x1b[90m└{dashes}{suffix}\x1b[0m",)?;
+            format!("\x1b[90m└{dashes}{suffix}\x1b[0m")
         } else {
             let dashes = "─".repeat(frame_width.saturating_sub(2));
-            write!(out, "\x1b[{row};1H\x1b[2K\x1b[90m└{dashes}┘\x1b[0m",)?;
+            format!("\x1b[90m└{dashes}┘\x1b[0m")
+        };
+        frame.push(line);
+    }
+
+    frame
+}
+
+/// SGR-wrapped glyph for tu's synthetic mouse cursor. Idle = magenta `△`;
+/// held = bright-white `△` on a magenta cell.
+fn mouse_cursor_glyph(held: bool) -> &'static str {
+    if held {
+        "\x1b[1;48;5;201;97m△"
+    } else {
+        "\x1b[1;38;5;201m△"
+    }
+}
+
+/// Diff the new frame against the previously-emitted one and only re-emit rows
+/// that actually changed. Wraps the writes in DECSET 2026 (synchronized output
+/// mode) so terminals that support it commit the frame atomically — eliminates
+/// the partial-clear flicker on slow links like SSH.
+fn emit_frame_diff(prev: Option<&[String]>, new: &[String], session_name: &str) -> Result<()> {
+    let mut out = io::stdout().lock();
+
+    // Begin synchronized output. No-op on terminals that don't recognize 2026.
+    write!(out, "\x1b[?2026h")?;
+
+    // Refresh the OSC title (cheap, terminals dedupe internally).
+    write!(out, "\x1b]0;tu monitor: {session_name}\x07")?;
+
+    let prev_len = prev.map(|p| p.len()).unwrap_or(0);
+    for (i, line) in new.iter().enumerate() {
+        let unchanged = prev
+            .and_then(|p| p.get(i))
+            .map(|s| s == line)
+            .unwrap_or(false);
+        if unchanged {
+            continue;
         }
-        row += 1;
+        // 1-indexed terminal row.
+        let row = i + 1;
+        write!(out, "\x1b[{row};1H\x1b[2K{line}")?;
     }
 
-    // Clear any remaining rows below the frame
-    if row <= term_rows {
-        write!(out, "\x1b[{row};1H\x1b[J")?;
+    // If the new frame is shorter than the previous one, clear what's beyond.
+    if new.len() < prev_len {
+        write!(out, "\x1b[{};1H\x1b[J", new.len() + 1)?;
     }
 
+    // End synchronized output and flush.
+    write!(out, "\x1b[?2026l")?;
     out.flush()?;
     Ok(())
 }

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -52,12 +52,15 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
     let mut last_fetch = std::time::Instant::now() - Duration::from_secs(10); // force immediate first fetch
     let mut last_change = std::time::Instant::now();
     // True when the next emission needs to wipe the alt screen first
-    // (startup, session switch, error, resize). Set on entry to those
-    // states; cleared after the next successful emit.
+    // (startup, session switch, error, resize). Cleared after the next
+    // successful emit.
     let mut needs_clear = true;
-    // Track the previous frame's row count so we can clear leftovers when
-    // the new frame is shorter (e.g. switching to a smaller session).
-    let mut prev_row_count: usize = 0;
+    // Previously-emitted frame, kept for row-by-row diff. Each frame is built
+    // into a fresh `Vec<String>` and compared to this one; rows whose string
+    // matches the prior frame's are skipped, leaving the terminal undisturbed.
+    // This is the bulk of the flicker fix — at 30fps with a mostly-static
+    // inner app, a typical tick writes the status line and nothing else.
+    let mut prev_frame: Option<Vec<String>> = None;
 
     let fetch_interval = Duration::from_millis(FRAME_INTERVAL_MS);
 
@@ -68,7 +71,7 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
             last_term_size = term_size;
             last_rows = None;
             needs_clear = true;
-            prev_row_count = 0;
+            prev_frame = None;
             last_fetch = std::time::Instant::now() - fetch_interval; // force refetch
         }
 
@@ -80,7 +83,7 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
             if sessions.is_empty() {
                 draw_waiting_screen()?;
                 needs_clear = true;
-                prev_row_count = 0;
+                prev_frame = None;
                 match tty.read_key(Duration::from_millis(FRAME_INTERVAL_MS))? {
                     Some(Key::Quit) => break,
                     _ => continue,
@@ -120,19 +123,19 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
                         mouse_cursor,
                         mouse_held,
                     );
-                    emit_frame_full(
+                    emit_frame_diff(
                         needs_clear,
-                        prev_row_count,
+                        prev_frame.as_deref(),
                         &new_frame,
                         &sessions[*current_idx],
                     )?;
                     needs_clear = false;
-                    prev_row_count = new_frame.len();
+                    prev_frame = Some(new_frame);
                 }
                 Ok(Response::Error { message: _ }) => {
                     last_rows = None;
                     needs_clear = true;
-                    prev_row_count = 0;
+                    prev_frame = None;
                 }
                 _ => {}
             }
@@ -146,7 +149,7 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
                 *current_idx -= 1;
                 last_rows = None;
                 needs_clear = true;
-                prev_row_count = 0;
+                prev_frame = None;
                 last_fetch = std::time::Instant::now() - fetch_interval; // force refetch
             }
             Some(Key::Right) => {
@@ -155,7 +158,7 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
                     *current_idx += 1;
                     last_rows = None;
                     needs_clear = true;
-                    prev_row_count = 0;
+                    prev_frame = None;
                     last_fetch = std::time::Instant::now() - fetch_interval;
                 }
             }
@@ -392,19 +395,17 @@ fn mouse_cursor_glyph(held: bool) -> &'static str {
     }
 }
 
-/// Emit every row of the new frame. `needs_clear` triggers a full
-/// alt-screen wipe + OSC title before the rows go down — used on startup,
-/// session switches, errors, and terminal resizes.
+/// Emit only the rows that changed vs the previously-emitted frame.
 ///
-/// Why no diff? An earlier diff-based emitter cached a partial first frame
-/// (when the inner app was mid-paint) and subsequent ticks saw matching
-/// strings, so changed rows below the partial portion were never re-sent.
-/// The bandwidth saved was not worth the rendering bugs. Every frame now
-/// re-emits all rows; per-row `CSI 2K` keeps each line clean, and most
-/// terminals coalesce paint such that the user sees no flicker.
-fn emit_frame_full(
+/// `needs_clear` (set on startup / session switch / error / resize) wipes
+/// the alt screen first and forces a full redraw, regardless of `prev`.
+///
+/// Note: when no diff applies (every tick, the same status line, the same
+/// content rows), this writes nothing — the user's terminal is left alone.
+/// That's what kills the flicker compared to the full-repaint version.
+fn emit_frame_diff(
     needs_clear: bool,
-    prev_row_count: usize,
+    prev: Option<&[String]>,
     new: &[String],
     session_name: &str,
 ) -> Result<()> {
@@ -415,13 +416,29 @@ fn emit_frame_full(
         write!(out, "\x1b]0;tu monitor: {session_name}\x07")?;
     }
 
+    let prev_len = if needs_clear {
+        // After a wipe, every row in `new` differs from "the screen" (which
+        // is now empty). Treat prev as None for the diff loop.
+        0
+    } else {
+        prev.map(|p| p.len()).unwrap_or(0)
+    };
+
     for (i, line) in new.iter().enumerate() {
+        let unchanged = !needs_clear
+            && prev
+                .and_then(|p| p.get(i))
+                .map(|s| s == line)
+                .unwrap_or(false);
+        if unchanged {
+            continue;
+        }
         let row = i + 1;
         write!(out, "\x1b[{row};1H\x1b[2K{line}")?;
     }
 
-    // Clear leftovers if the previous frame was taller (e.g. resized smaller).
-    if new.len() < prev_row_count {
+    // If the new frame is shorter than the previous, clear what's beyond.
+    if new.len() < prev_len {
         write!(out, "\x1b[{};1H\x1b[J", new.len() + 1)?;
     }
 

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -187,7 +187,9 @@ fn draw_waiting_screen() -> Result<()> {
     let line3 = "Ctrl+C to quit";
     let box_width = 32;
     let pad_x = (cols as usize).saturating_sub(box_width) / 2;
-    let mid_row = rows / 2 - 2;
+    // saturating_sub guards against the overflow that would happen on a
+    // pathologically tiny terminal (rows < 4).
+    let mid_row = (rows / 2).saturating_sub(2).max(1);
     let p = " ".repeat(pad_x);
 
     write!(

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -390,8 +390,15 @@ fn emit_frame_diff(prev: Option<&[String]>, new: &[String], session_name: &str) 
     // Begin synchronized output. No-op on terminals that don't recognize 2026.
     write!(out, "\x1b[?2026h")?;
 
-    // Refresh the OSC title (cheap, terminals dedupe internally).
-    write!(out, "\x1b]0;tu monitor: {session_name}\x07")?;
+    // First emission after a transition (startup, session switch, error,
+    // resize) — wipe the alt screen so we know we're rendering on top of a
+    // clean slate. Without this, leftovers from the waiting screen, a previous
+    // session's frame, or partial mid-render artifacts can survive on rows
+    // the diff later considers "unchanged" and never re-emits.
+    if prev.is_none() {
+        write!(out, "\x1b[2J\x1b[H")?;
+        write!(out, "\x1b]0;tu monitor: {session_name}\x07")?;
+    }
 
     let prev_len = prev.map(|p| p.len()).unwrap_or(0);
     for (i, line) in new.iter().enumerate() {
@@ -468,8 +475,15 @@ impl RawTerminal {
 
         termios::tcsetattr(io::stdin(), termios::SetArg::TCSANOW, &raw).context("tcsetattr raw")?;
 
-        // Enter alternate screen + hide cursor
-        print!("\x1b[?1049h\x1b[?25l");
+        // Enter alternate screen + hide cursor + disable autowrap.
+        //
+        // Autowrap-off (DECRST 7) matters with the diff-based emit path: if a
+        // session is wider than the user's terminal, raw cell content would
+        // overflow into the row below, and the diff would never re-clear that
+        // row when its model contents stayed "the same". With autowrap off
+        // the overflow is silently dropped and rows stay confined to their
+        // own line.
+        print!("\x1b[?1049h\x1b[?25l\x1b[?7l");
         io::stdout().flush()?;
 
         Ok(Self {
@@ -522,8 +536,8 @@ impl RawTerminal {
 
 impl Drop for RawTerminal {
     fn drop(&mut self) {
-        // Restore terminal: show cursor + leave alternate screen
-        print!("\x1b[?25h\x1b[?1049l");
+        // Restore terminal: re-enable autowrap, show cursor, leave alt screen.
+        print!("\x1b[?7h\x1b[?25h\x1b[?1049l");
         let _ = io::stdout().flush();
 
         // Restore original termios

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -97,9 +97,11 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
             }
 
             // Just emerged from the waiting state — let the inner app finish
-            // its initial paint before snapshotting.
+            // its initial paint before snapshotting. mc on macOS routinely
+            // takes ~250-400ms to fully draw its panels; 400ms is a
+            // conservative buffer that still feels instant interactively.
             if just_attached {
-                tokio::time::sleep(Duration::from_millis(150)).await;
+                tokio::time::sleep(Duration::from_millis(400)).await;
                 just_attached = false;
             }
 

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -51,11 +51,13 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
     let mut last_term_size = get_terminal_size();
     let mut last_fetch = std::time::Instant::now() - Duration::from_secs(10); // force immediate first fetch
     let mut last_change = std::time::Instant::now();
-    // Diff state: the previously-emitted frame as a vector of one ANSI string per
-    // visible terminal row. Each new frame is rendered into a fresh `Vec<String>`
-    // and compared row-by-row; only changed rows are written to stdout. This is
-    // the bulk of the flicker fix — most rows stay byte-identical between frames.
-    let mut prev_frame: Option<Vec<String>> = None;
+    // True when the next emission needs to wipe the alt screen first
+    // (startup, session switch, error, resize). Set on entry to those
+    // states; cleared after the next successful emit.
+    let mut needs_clear = true;
+    // Track the previous frame's row count so we can clear leftovers when
+    // the new frame is shorter (e.g. switching to a smaller session).
+    let mut prev_row_count: usize = 0;
     // True the first time we observe a session after the waiting state. We
     // give the inner app a brief moment to finish its initial paint before
     // snapshotting — without this, a freshly-spawned mc/vim/htop is often
@@ -68,10 +70,10 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
         // Detect terminal resize → clear screen + force redraw
         let term_size = get_terminal_size();
         if term_size != last_term_size {
-            print!("\x1b[2J");
             last_term_size = term_size;
             last_rows = None;
-            prev_frame = None;
+            needs_clear = true;
+            prev_row_count = 0;
             last_fetch = std::time::Instant::now() - fetch_interval; // force refetch
         }
 
@@ -82,7 +84,8 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
             let sessions = get_session_names().await.unwrap_or_default();
             if sessions.is_empty() {
                 draw_waiting_screen()?;
-                prev_frame = None;
+                needs_clear = true;
+                prev_row_count = 0;
                 just_attached = true;
                 match tty.read_key(Duration::from_millis(FRAME_INTERVAL_MS))? {
                     Some(Key::Quit) => break,
@@ -130,12 +133,19 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
                         mouse_cursor,
                         mouse_held,
                     );
-                    emit_frame_diff(prev_frame.as_deref(), &new_frame, &sessions[*current_idx])?;
-                    prev_frame = Some(new_frame);
+                    emit_frame_full(
+                        needs_clear,
+                        prev_row_count,
+                        &new_frame,
+                        &sessions[*current_idx],
+                    )?;
+                    needs_clear = false;
+                    prev_row_count = new_frame.len();
                 }
                 Ok(Response::Error { message: _ }) => {
                     last_rows = None;
-                    prev_frame = None;
+                    needs_clear = true;
+                    prev_row_count = 0;
                 }
                 _ => {}
             }
@@ -148,7 +158,8 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
             Some(Key::Left) if *current_idx > 0 => {
                 *current_idx -= 1;
                 last_rows = None;
-                prev_frame = None;
+                needs_clear = true;
+                prev_row_count = 0;
                 last_fetch = std::time::Instant::now() - fetch_interval; // force refetch
             }
             Some(Key::Right) => {
@@ -156,7 +167,8 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
                 if *current_idx + 1 < sessions.len() {
                     *current_idx += 1;
                     last_rows = None;
-                    prev_frame = None;
+                    needs_clear = true;
+                    prev_row_count = 0;
                     last_fetch = std::time::Instant::now() - fetch_interval;
                 }
             }
@@ -393,43 +405,36 @@ fn mouse_cursor_glyph(held: bool) -> &'static str {
     }
 }
 
-/// Diff the new frame against the previously-emitted one and only re-emit rows
-/// that actually changed.
+/// Emit every row of the new frame. `needs_clear` triggers a full
+/// alt-screen wipe + OSC title before the rows go down — used on startup,
+/// session switches, errors, and terminal resizes.
 ///
-/// (We avoid DECSET 2026 / synchronized output mode here: in practice it
-/// behaves inconsistently across the terminals we care about — at least one
-/// SSH terminal we tested ate frames mid-sync. The diff alone gives most of
-/// the flicker reduction; the per-row CSI 2K + write is small enough that
-/// terminals with their own paint coalescing handle it cleanly.)
-fn emit_frame_diff(prev: Option<&[String]>, new: &[String], session_name: &str) -> Result<()> {
+/// Why no diff? An earlier diff-based emitter cached a partial first frame
+/// (when the inner app was mid-paint) and subsequent ticks saw matching
+/// strings, so changed rows below the partial portion were never re-sent.
+/// The bandwidth saved was not worth the rendering bugs. Every frame now
+/// re-emits all rows; per-row `CSI 2K` keeps each line clean, and most
+/// terminals coalesce paint such that the user sees no flicker.
+fn emit_frame_full(
+    needs_clear: bool,
+    prev_row_count: usize,
+    new: &[String],
+    session_name: &str,
+) -> Result<()> {
     let mut out = io::stdout().lock();
 
-    // First emission after a transition (startup, session switch, error,
-    // resize) — wipe the alt screen so we know we're rendering on top of a
-    // clean slate. Without this, leftovers from the waiting screen, a previous
-    // session's frame, or partial mid-render artifacts can survive on rows
-    // the diff later considers "unchanged" and never re-emits.
-    if prev.is_none() {
+    if needs_clear {
         write!(out, "\x1b[2J\x1b[H")?;
         write!(out, "\x1b]0;tu monitor: {session_name}\x07")?;
     }
 
-    let prev_len = prev.map(|p| p.len()).unwrap_or(0);
     for (i, line) in new.iter().enumerate() {
-        let unchanged = prev
-            .and_then(|p| p.get(i))
-            .map(|s| s == line)
-            .unwrap_or(false);
-        if unchanged {
-            continue;
-        }
-        // 1-indexed terminal row.
         let row = i + 1;
         write!(out, "\x1b[{row};1H\x1b[2K{line}")?;
     }
 
-    // If the new frame is shorter than the previous one, clear what's beyond.
-    if new.len() < prev_len {
+    // Clear leftovers if the previous frame was taller (e.g. resized smaller).
+    if new.len() < prev_row_count {
         write!(out, "\x1b[{};1H\x1b[J", new.len() + 1)?;
     }
 

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -58,11 +58,6 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
     // Track the previous frame's row count so we can clear leftovers when
     // the new frame is shorter (e.g. switching to a smaller session).
     let mut prev_row_count: usize = 0;
-    // True the first time we observe a session after the waiting state. We
-    // give the inner app a brief moment to finish its initial paint before
-    // snapshotting — without this, a freshly-spawned mc/vim/htop is often
-    // mid-render on the first vt100 read and the user sees a partial frame.
-    let mut just_attached = true;
 
     let fetch_interval = Duration::from_millis(FRAME_INTERVAL_MS);
 
@@ -86,7 +81,6 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
                 draw_waiting_screen()?;
                 needs_clear = true;
                 prev_row_count = 0;
-                just_attached = true;
                 match tty.read_key(Duration::from_millis(FRAME_INTERVAL_MS))? {
                     Some(Key::Quit) => break,
                     _ => continue,
@@ -94,15 +88,6 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
             }
             if *current_idx >= sessions.len() {
                 *current_idx = sessions.len() - 1;
-            }
-
-            // Just emerged from the waiting state — let the inner app finish
-            // its initial paint before snapshotting. mc on macOS routinely
-            // takes ~250-400ms to fully draw its panels; 400ms is a
-            // conservative buffer that still feels instant interactively.
-            if just_attached {
-                tokio::time::sleep(Duration::from_millis(400)).await;
-                just_attached = false;
             }
 
             let session_name = &sessions[*current_idx];
@@ -494,15 +479,8 @@ impl RawTerminal {
 
         termios::tcsetattr(io::stdin(), termios::SetArg::TCSANOW, &raw).context("tcsetattr raw")?;
 
-        // Enter alternate screen + hide cursor + disable autowrap.
-        //
-        // Autowrap-off (DECRST 7) matters with the diff-based emit path: if a
-        // session is wider than the user's terminal, raw cell content would
-        // overflow into the row below, and the diff would never re-clear that
-        // row when its model contents stayed "the same". With autowrap off
-        // the overflow is silently dropped and rows stay confined to their
-        // own line.
-        print!("\x1b[?1049h\x1b[?25l\x1b[?7l");
+        // Enter alternate screen + hide cursor.
+        print!("\x1b[?1049h\x1b[?25l");
         io::stdout().flush()?;
 
         Ok(Self {
@@ -555,8 +533,8 @@ impl RawTerminal {
 
 impl Drop for RawTerminal {
     fn drop(&mut self) {
-        // Restore terminal: re-enable autowrap, show cursor, leave alt screen.
-        print!("\x1b[?7h\x1b[?25h\x1b[?1049l");
+        // Restore terminal: show cursor, leave alt screen.
+        print!("\x1b[?25h\x1b[?1049l");
         let _ = io::stdout().flush();
 
         // Restore original termios

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -56,6 +56,11 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
     // and compared row-by-row; only changed rows are written to stdout. This is
     // the bulk of the flicker fix — most rows stay byte-identical between frames.
     let mut prev_frame: Option<Vec<String>> = None;
+    // True the first time we observe a session after the waiting state. We
+    // give the inner app a brief moment to finish its initial paint before
+    // snapshotting — without this, a freshly-spawned mc/vim/htop is often
+    // mid-render on the first vt100 read and the user sees a partial frame.
+    let mut just_attached = true;
 
     let fetch_interval = Duration::from_millis(FRAME_INTERVAL_MS);
 
@@ -78,6 +83,7 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
             if sessions.is_empty() {
                 draw_waiting_screen()?;
                 prev_frame = None;
+                just_attached = true;
                 match tty.read_key(Duration::from_millis(FRAME_INTERVAL_MS))? {
                     Some(Key::Quit) => break,
                     _ => continue,
@@ -85,6 +91,13 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
             }
             if *current_idx >= sessions.len() {
                 *current_idx = sessions.len() - 1;
+            }
+
+            // Just emerged from the waiting state — let the inner app finish
+            // its initial paint before snapshotting.
+            if just_attached {
+                tokio::time::sleep(Duration::from_millis(150)).await;
+                just_attached = false;
             }
 
             let session_name = &sessions[*current_idx];
@@ -381,14 +394,15 @@ fn mouse_cursor_glyph(held: bool) -> &'static str {
 }
 
 /// Diff the new frame against the previously-emitted one and only re-emit rows
-/// that actually changed. Wraps the writes in DECSET 2026 (synchronized output
-/// mode) so terminals that support it commit the frame atomically — eliminates
-/// the partial-clear flicker on slow links like SSH.
+/// that actually changed.
+///
+/// (We avoid DECSET 2026 / synchronized output mode here: in practice it
+/// behaves inconsistently across the terminals we care about — at least one
+/// SSH terminal we tested ate frames mid-sync. The diff alone gives most of
+/// the flicker reduction; the per-row CSI 2K + write is small enough that
+/// terminals with their own paint coalescing handle it cleanly.)
 fn emit_frame_diff(prev: Option<&[String]>, new: &[String], session_name: &str) -> Result<()> {
     let mut out = io::stdout().lock();
-
-    // Begin synchronized output. No-op on terminals that don't recognize 2026.
-    write!(out, "\x1b[?2026h")?;
 
     // First emission after a transition (startup, session switch, error,
     // resize) — wipe the alt screen so we know we're rendering on top of a
@@ -419,8 +433,6 @@ fn emit_frame_diff(prev: Option<&[String]>, new: &[String], session_name: &str) 
         write!(out, "\x1b[{};1H\x1b[J", new.len() + 1)?;
     }
 
-    // End synchronized output and flush.
-    write!(out, "\x1b[?2026l")?;
     out.flush()?;
     Ok(())
 }

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 
-use crate::daemon::protocol::{CursorPos, Request, Response};
+use crate::daemon::protocol::{Request, Response};
 use crate::daemon::server::{ensure_daemon, send_request};
 
 /// Run the attach live viewer.
@@ -91,8 +91,6 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
                     rows_ansi,
                     rows,
                     cols,
-                    mouse_cursor,
-                    mouse_held,
                 }) => {
                     let changed = last_rows.as_ref() != Some(&rows_ansi);
                     if changed {
@@ -108,8 +106,6 @@ async fn run_loop(tty: &mut RawTerminal, current_idx: &mut usize) -> Result<()> 
                         cols,
                         term_size,
                         last_change.elapsed(),
-                        mouse_cursor,
-                        mouse_held,
                     )?;
                 }
                 Ok(Response::Error { message: _ }) => {
@@ -232,7 +228,6 @@ fn format_elapsed(d: Duration) -> String {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn draw_frame(
     sessions: &[String],
     active_idx: usize,
@@ -241,8 +236,6 @@ fn draw_frame(
     sess_cols: u16,
     term_size: (u16, u16),
     since_last_change: Duration,
-    mouse_cursor: Option<CursorPos>,
-    mouse_held: bool,
 ) -> Result<()> {
     let (term_cols, term_rows) = term_size;
     let mut out = io::stdout().lock();
@@ -362,45 +355,8 @@ fn draw_frame(
         write!(out, "\x1b[{row};1H\x1b[J")?;
     }
 
-    // Synthetic mouse cursor overlay: tu's last-known position lives outside
-    // any application's rendering, so we paint it on top after the inner app's
-    // own output.
-    if let Some(cursor) = mouse_cursor {
-        if cursor.col < sess_cols && cursor.row < sess_rows {
-            // Layout: status(1) + [tabs(1)] + top border(1) + content rows
-            let header_rows: u16 = if sessions.len() > 1 { 3 } else { 2 };
-            let content_first = header_rows + 1; // content[0] sits one row past the header rows
-            let term_row = content_first + cursor.row;
-            // Frame's left border occupies column 1; content starts at column 2.
-            let term_col = 2 + cursor.col;
-            // Stay inside the visible area (avoid drawing on or past the
-            // bottom-fade ellipsis or right-clip rules).
-            let max_content_row = (header_rows + sess_rows).min(term_rows);
-            let max_visible_col = if term_cols >= 2 { term_cols - 1 } else { 0 };
-            if term_row <= max_content_row && term_col <= max_visible_col + 1 {
-                let body = mouse_cursor_glyph(mouse_held);
-                write!(out, "\x1b[{term_row};{term_col}H{body}\x1b[0m")?;
-            }
-        }
-    }
-
     out.flush()?;
     Ok(())
-}
-
-/// SGR-wrapped single-cell glyph for the synthetic mouse cursor.
-///
-/// The colour is bright magenta (chosen to be uncommon in TUIs so it doesn't
-/// blend in). Held = filled block; idle = outline so the underlying cell
-/// stays partially readable.
-fn mouse_cursor_glyph(held: bool) -> &'static str {
-    if held {
-        // Bright magenta bg + bright white fg + bold + filled block.
-        "\x1b[1;48;5;201;97m█"
-    } else {
-        // Bright magenta fg, bold, hollow box. Underlying cell colour stays.
-        "\x1b[1;38;5;201m▢"
-    }
 }
 
 fn build_tab_bar(sessions: &[String], active_idx: usize) -> String {

--- a/src/commands/mouse.rs
+++ b/src/commands/mouse.rs
@@ -285,7 +285,14 @@ pub async fn run(cmd: MouseCmd, format: Format) -> Result<()> {
 
 async fn run_state(name: String, format: Format) -> Result<()> {
     match send_request(&Request::MouseState { name }).await? {
-        Response::MouseState { mode, encoding } => {
+        Response::MouseState {
+            mode,
+            encoding,
+            size,
+            cursor,
+            buttons_held,
+            last_event,
+        } => {
             use crate::daemon::protocol::MouseMode;
             match format {
                 Format::Human => {
@@ -294,12 +301,55 @@ async fn run_state(name: String, format: Format) -> Result<()> {
                     } else {
                         println!("mode={mode:?} encoding={encoding:?}");
                     }
+                    let cursor_str = match cursor {
+                        Some(p) => format!("({},{})", p.col, p.row),
+                        None => "none".into(),
+                    };
+                    println!("cursor={cursor_str} screensize={}x{}", size.cols, size.rows);
+                    let held_str = if buttons_held.is_empty() {
+                        "none".to_string()
+                    } else {
+                        buttons_held
+                            .iter()
+                            .map(|b| format!("{b:?}").to_lowercase())
+                            .collect::<Vec<_>>()
+                            .join(",")
+                    };
+                    println!("buttons_held={held_str}");
+                    match last_event {
+                        Some(ev) => {
+                            let kind = format!("{:?}", ev.kind);
+                            let extra = match (ev.button, ev.scroll_dir) {
+                                (Some(b), _) => format!(" button={b:?}").to_lowercase(),
+                                (_, Some(d)) => format!(" dir={d:?}").to_lowercase(),
+                                _ => String::new(),
+                            };
+                            let mods_str = mods_to_str(&ev.mods);
+                            let mods_part = if mods_str.is_empty() {
+                                String::new()
+                            } else {
+                                format!(" mods={mods_str}")
+                            };
+                            println!(
+                                "last_event={} ({},{}){}{} at {}",
+                                kind, ev.col, ev.row, extra, mods_part, ev.ts_unix
+                            );
+                        }
+                        None => println!("last_event=none"),
+                    }
                 }
                 Format::Json => {
                     let v = serde_json::json!({
                         "mode": format!("{mode:?}"),
                         "encoding": format!("{encoding:?}"),
                         "enabled": mode != MouseMode::None,
+                        "size": { "cols": size.cols, "rows": size.rows },
+                        "cursor": cursor.map(|p| serde_json::json!({"col": p.col, "row": p.row})),
+                        "buttons_held": buttons_held
+                            .iter()
+                            .map(|b| format!("{b:?}").to_lowercase())
+                            .collect::<Vec<_>>(),
+                        "last_event": last_event,
                     });
                     println!("{v}");
                 }
@@ -309,6 +359,20 @@ async fn run_state(name: String, format: Format) -> Result<()> {
         Response::Error { message } => bail!("{message}"),
         other => bail!("Unexpected response: {other:?}"),
     }
+}
+
+fn mods_to_str(mods: &crate::daemon::protocol::MouseMods) -> String {
+    let mut parts = Vec::new();
+    if mods.ctrl {
+        parts.push("ctrl");
+    }
+    if mods.shift {
+        parts.push("shift");
+    }
+    if mods.alt {
+        parts.push("alt");
+    }
+    parts.join(",")
 }
 
 async fn send_action(name: &str, action: MouseAction, force: bool) -> Result<()> {

--- a/src/commands/mouse.rs
+++ b/src/commands/mouse.rs
@@ -1,0 +1,427 @@
+//! `tu mouse …` CLI dispatch.
+//!
+//! Coordinates exposed to the user are 0-based, matching `cursor` /
+//! `screenshot`. Targeting flags (`--on-text`, `--on-regex`) replace positional
+//! coords by searching the visible screen and clicking the center of the
+//! resolved match.
+
+use anyhow::{bail, Result};
+use clap::{Args, Subcommand};
+
+use crate::daemon::protocol::{
+    MouseAction, MouseButton, MouseTarget, Request, Response, ScrollDir,
+};
+use crate::daemon::server::{ensure_daemon, send_request};
+use crate::mouse;
+use crate::output::Format;
+
+#[derive(Debug, Subcommand)]
+pub enum MouseCmd {
+    /// Click at coordinates or on text.
+    Click {
+        /// Column (0-based). Omit when using --on-text / --on-regex.
+        col: Option<u16>,
+        /// Row (0-based). Omit when using --on-text / --on-regex.
+        row: Option<u16>,
+
+        #[command(flatten)]
+        target: TargetOpts,
+
+        #[command(flatten)]
+        common: CommonOpts,
+
+        /// Mouse button.
+        #[arg(long, default_value = "left", value_parser = mouse::parse_button)]
+        button: MouseButton,
+
+        /// Multi-click count (2 = double-click, 3 = triple-click).
+        #[arg(long, default_value = "1")]
+        clicks: u32,
+    },
+
+    /// Press a button without releasing.
+    Down {
+        col: Option<u16>,
+        row: Option<u16>,
+
+        #[command(flatten)]
+        target: TargetOpts,
+
+        #[command(flatten)]
+        common: CommonOpts,
+
+        #[arg(long, default_value = "left", value_parser = mouse::parse_button)]
+        button: MouseButton,
+    },
+
+    /// Release a button.
+    Up {
+        col: Option<u16>,
+        row: Option<u16>,
+
+        #[command(flatten)]
+        target: TargetOpts,
+
+        #[command(flatten)]
+        common: CommonOpts,
+
+        #[arg(long, default_value = "left", value_parser = mouse::parse_button)]
+        button: MouseButton,
+    },
+
+    /// Move the cursor (requires AnyMotion or ButtonMotion mode).
+    Move {
+        col: Option<u16>,
+        row: Option<u16>,
+
+        #[command(flatten)]
+        target: TargetOpts,
+
+        #[command(flatten)]
+        common: CommonOpts,
+    },
+
+    /// Drag from one cell to another (atomic down → motion → up).
+    Drag {
+        col1: u16,
+        row1: u16,
+        col2: u16,
+        row2: u16,
+
+        #[command(flatten)]
+        common: CommonOpts,
+
+        #[arg(long, default_value = "left", value_parser = mouse::parse_button)]
+        button: MouseButton,
+    },
+
+    /// Scroll wheel.
+    Scroll {
+        /// Direction.
+        #[arg(value_parser = mouse::parse_scroll_dir)]
+        dir: ScrollDir,
+
+        col: Option<u16>,
+        row: Option<u16>,
+
+        #[command(flatten)]
+        target: TargetOpts,
+
+        #[command(flatten)]
+        common: CommonOpts,
+
+        /// Number of wheel notches.
+        #[arg(long, default_value = "1")]
+        amount: u32,
+    },
+
+    /// Print the inner app's mouse mode + encoding.
+    State {
+        #[arg(long, default_value = "default")]
+        name: String,
+    },
+}
+
+#[derive(Debug, Args, Clone, Default)]
+pub struct TargetOpts {
+    /// Click on first match of literal text on the visible screen.
+    #[arg(long, value_name = "TEXT")]
+    pub on_text: Option<String>,
+    /// Click on first match of regex.
+    #[arg(long, value_name = "REGEX")]
+    pub on_regex: Option<String>,
+    /// 0-based index when there are multiple matches.
+    #[arg(long, default_value = "0")]
+    pub match_index: usize,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct CommonOpts {
+    /// Modifier keys (comma-separated): Ctrl,Shift,Alt.
+    #[arg(long, default_value = "")]
+    pub mods: String,
+    /// Session name.
+    #[arg(long, default_value = "default")]
+    pub name: String,
+    /// Send even if the inner app has not enabled mouse reporting.
+    #[arg(long)]
+    pub force: bool,
+}
+
+pub async fn run(cmd: MouseCmd, format: Format) -> Result<()> {
+    ensure_daemon()?;
+
+    match cmd {
+        MouseCmd::State { name } => run_state(name, format).await,
+        MouseCmd::Click {
+            col,
+            row,
+            target,
+            common,
+            button,
+            clicks,
+        } => {
+            let target = build_target(col, row, &target)?;
+            let mods = mouse::parse_mods(&common.mods)?;
+            send_action(
+                &common.name,
+                MouseAction::Click {
+                    target,
+                    button,
+                    mods,
+                    clicks,
+                },
+                common.force,
+            )
+            .await
+        }
+        MouseCmd::Down {
+            col,
+            row,
+            target,
+            common,
+            button,
+        } => {
+            let target = build_target(col, row, &target)?;
+            let mods = mouse::parse_mods(&common.mods)?;
+            send_action(
+                &common.name,
+                MouseAction::Down {
+                    target,
+                    button,
+                    mods,
+                },
+                common.force,
+            )
+            .await
+        }
+        MouseCmd::Up {
+            col,
+            row,
+            target,
+            common,
+            button,
+        } => {
+            let target = build_target(col, row, &target)?;
+            let mods = mouse::parse_mods(&common.mods)?;
+            send_action(
+                &common.name,
+                MouseAction::Up {
+                    target,
+                    button,
+                    mods,
+                },
+                common.force,
+            )
+            .await
+        }
+        MouseCmd::Move {
+            col,
+            row,
+            target,
+            common,
+        } => {
+            let target = build_target(col, row, &target)?;
+            let mods = mouse::parse_mods(&common.mods)?;
+            send_action(
+                &common.name,
+                MouseAction::Move { target, mods },
+                common.force,
+            )
+            .await
+        }
+        MouseCmd::Drag {
+            col1,
+            row1,
+            col2,
+            row2,
+            common,
+            button,
+        } => {
+            let mods = mouse::parse_mods(&common.mods)?;
+            send_action(
+                &common.name,
+                MouseAction::Drag {
+                    from: MouseTarget::Coords {
+                        col: col1,
+                        row: row1,
+                    },
+                    to: MouseTarget::Coords {
+                        col: col2,
+                        row: row2,
+                    },
+                    button,
+                    mods,
+                },
+                common.force,
+            )
+            .await
+        }
+        MouseCmd::Scroll {
+            dir,
+            col,
+            row,
+            target,
+            common,
+            amount,
+        } => {
+            let mods = mouse::parse_mods(&common.mods)?;
+            // For scroll, target is optional (defaults to top-left).
+            let resolved = build_optional_target(col, row, &target)?;
+            send_action(
+                &common.name,
+                MouseAction::Scroll {
+                    target: resolved,
+                    dir,
+                    amount,
+                    mods,
+                },
+                common.force,
+            )
+            .await
+        }
+    }
+}
+
+async fn run_state(name: String, format: Format) -> Result<()> {
+    match send_request(&Request::MouseState { name }).await? {
+        Response::MouseState { mode, encoding } => {
+            use crate::daemon::protocol::MouseMode;
+            match format {
+                Format::Human => {
+                    if mode == MouseMode::None {
+                        println!("disabled");
+                    } else {
+                        println!("mode={mode:?} encoding={encoding:?}");
+                    }
+                }
+                Format::Json => {
+                    let v = serde_json::json!({
+                        "mode": format!("{mode:?}"),
+                        "encoding": format!("{encoding:?}"),
+                        "enabled": mode != MouseMode::None,
+                    });
+                    println!("{v}");
+                }
+            }
+            Ok(())
+        }
+        Response::Error { message } => bail!("{message}"),
+        other => bail!("Unexpected response: {other:?}"),
+    }
+}
+
+async fn send_action(name: &str, action: MouseAction, force: bool) -> Result<()> {
+    let req = Request::Mouse {
+        name: name.to_string(),
+        action,
+        force,
+    };
+    match send_request(&req).await? {
+        Response::Ok => Ok(()),
+        Response::Error { message } => bail!("{message}"),
+        other => bail!("Unexpected response: {other:?}"),
+    }
+}
+
+fn build_target(col: Option<u16>, row: Option<u16>, t: &TargetOpts) -> Result<MouseTarget> {
+    let positional = match (col, row) {
+        (Some(c), Some(r)) => Some((c, r)),
+        (None, None) => None,
+        _ => bail!("provide both <col> and <row>, or neither (with --on-text / --on-regex)"),
+    };
+
+    match (positional, t.on_text.as_deref(), t.on_regex.as_deref()) {
+        (Some((c, r)), None, None) => Ok(MouseTarget::Coords { col: c, row: r }),
+        (None, Some(needle), None) => Ok(MouseTarget::Text {
+            needle: needle.to_string(),
+            match_index: t.match_index,
+        }),
+        (None, None, Some(pat)) => Ok(MouseTarget::Regex {
+            pattern: pat.to_string(),
+            match_index: t.match_index,
+        }),
+        (None, None, None) => bail!("no target: provide <col> <row>, --on-text, or --on-regex"),
+        _ => bail!("specify exactly one of: positional <col> <row>, --on-text, --on-regex"),
+    }
+}
+
+fn build_optional_target(
+    col: Option<u16>,
+    row: Option<u16>,
+    t: &TargetOpts,
+) -> Result<Option<MouseTarget>> {
+    if col.is_none() && row.is_none() && t.on_text.is_none() && t.on_regex.is_none() {
+        return Ok(None);
+    }
+    Ok(Some(build_target(col, row, t)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_target() -> TargetOpts {
+        TargetOpts::default()
+    }
+
+    #[test]
+    fn build_target_coords_pair() {
+        let t = build_target(Some(5), Some(7), &empty_target()).unwrap();
+        assert!(matches!(t, MouseTarget::Coords { col: 5, row: 7 }));
+    }
+
+    #[test]
+    fn build_target_on_text() {
+        let mut opts = empty_target();
+        opts.on_text = Some("Buy".into());
+        let t = build_target(None, None, &opts).unwrap();
+        assert!(matches!(t, MouseTarget::Text { ref needle, match_index: 0 } if needle == "Buy"));
+    }
+
+    #[test]
+    fn build_target_on_regex_with_match_index() {
+        let mut opts = empty_target();
+        opts.on_regex = Some(r"\d+".into());
+        opts.match_index = 2;
+        let t = build_target(None, None, &opts).unwrap();
+        assert!(
+            matches!(t, MouseTarget::Regex { ref pattern, match_index: 2 } if pattern == r"\d+")
+        );
+    }
+
+    #[test]
+    fn build_target_partial_coords_errors() {
+        assert!(build_target(Some(1), None, &empty_target()).is_err());
+        assert!(build_target(None, Some(1), &empty_target()).is_err());
+    }
+
+    #[test]
+    fn build_target_no_input_errors() {
+        assert!(build_target(None, None, &empty_target()).is_err());
+    }
+
+    #[test]
+    fn build_target_conflicting_inputs_errors() {
+        let mut opts = empty_target();
+        opts.on_text = Some("X".into());
+        assert!(build_target(Some(1), Some(1), &opts).is_err());
+
+        let mut opts = empty_target();
+        opts.on_text = Some("X".into());
+        opts.on_regex = Some("Y".into());
+        assert!(build_target(None, None, &opts).is_err());
+    }
+
+    #[test]
+    fn build_optional_target_none_is_ok() {
+        let t = build_optional_target(None, None, &empty_target()).unwrap();
+        assert!(t.is_none());
+    }
+
+    #[test]
+    fn build_optional_target_with_coords() {
+        let t = build_optional_target(Some(0), Some(0), &empty_target()).unwrap();
+        assert!(matches!(t, Some(MouseTarget::Coords { col: 0, row: 0 })));
+    }
+}

--- a/src/commands/screenshot.rs
+++ b/src/commands/screenshot.rs
@@ -21,18 +21,36 @@ pub async fn run_text(name: String, format: Format) -> Result<()> {
             rows,
             cols,
             cursor,
+            mouse_cursor,
+            mouse_held,
         } => {
             match format {
                 Format::Human => {
                     println!(
                         "{}",
-                        text::format_screenshot(&content, rows, cols, cursor.row, cursor.col)
+                        text::format_screenshot(
+                            &content,
+                            rows,
+                            cols,
+                            cursor.row,
+                            cursor.col,
+                            mouse_cursor,
+                            mouse_held,
+                        )
                     );
                 }
                 Format::Json => {
                     println!(
                         "{}",
-                        text::format_screenshot_json(&content, rows, cols, cursor.row, cursor.col)
+                        text::format_screenshot_json(
+                            &content,
+                            rows,
+                            cols,
+                            cursor.row,
+                            cursor.col,
+                            mouse_cursor,
+                            mouse_held,
+                        )
                     );
                 }
             }

--- a/src/commands/screenshot.rs
+++ b/src/commands/screenshot.rs
@@ -43,33 +43,48 @@ pub async fn run_text(name: String, format: Format) -> Result<()> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run_png(
     name: String,
     output: Option<PathBuf>,
     stdout: bool,
     font: Option<String>,
     font_size: f32,
+    show_cursor: bool,
 ) -> Result<()> {
     ensure_daemon()?;
 
     let response = send_request(&Request::ScreenshotAnsi { name: name.clone() }).await?;
-    let (ansi_bytes, rows, cols) = match response {
+    let (ansi_bytes, rows, cols, mouse_cursor, mouse_held) = match response {
         Response::ScreenshotAnsi {
             content_b64,
             rows,
             cols,
+            mouse_cursor,
+            mouse_held,
         } => (
             base64::engine::general_purpose::STANDARD
                 .decode(content_b64)
                 .context("invalid base64 ANSI snapshot")?,
             rows,
             cols,
+            mouse_cursor,
+            mouse_held,
         ),
         Response::Error { message } => anyhow::bail!("{message}"),
         other => anyhow::bail!("Unexpected response: {other:?}"),
     };
 
-    let screenshot = build_screenshot(&ansi_bytes, rows, cols, font, font_size)?;
+    let cursor_for_render = if show_cursor { mouse_cursor } else { None };
+    let screenshot = build_screenshot(
+        &ansi_bytes,
+        rows,
+        cols,
+        font,
+        font_size,
+        cursor_for_render,
+        mouse_held,
+    )?;
 
     if stdout {
         let png = screenshot.to_png()?;
@@ -91,6 +106,8 @@ fn build_screenshot(
     cols: u16,
     font: Option<String>,
     font_size: f32,
+    mouse_cursor: Option<crate::daemon::protocol::CursorPos>,
+    mouse_held: bool,
 ) -> Result<Screenshot> {
     let mut parser = vt100::Parser::new(rows, cols, 0);
     parser.process(ansi_bytes);
@@ -99,6 +116,9 @@ fn build_screenshot(
     let mut screenshot = Screenshot::new(screen).font_size(font_size);
     if let Some(font_path) = font {
         screenshot = screenshot.font_path(&font_path);
+    }
+    if let Some(pos) = mouse_cursor {
+        screenshot = screenshot.mouse_cursor(pos.col, pos.row, mouse_held);
     }
 
     Ok(screenshot)
@@ -110,7 +130,17 @@ mod tests {
 
     #[test]
     fn build_screenshot_generates_png_bytes() {
-        let screenshot = build_screenshot(b"\x1b[31mhello\x1b[0m", 4, 20, None, 14.0).unwrap();
+        let screenshot =
+            build_screenshot(b"\x1b[31mhello\x1b[0m", 4, 20, None, 14.0, None, false).unwrap();
+        let png = screenshot.to_png().unwrap();
+        assert!(png.starts_with(b"\x89PNG\r\n\x1a\n"));
+    }
+
+    #[test]
+    fn build_screenshot_with_cursor_overlay_still_emits_png() {
+        let cursor = Some(crate::daemon::protocol::CursorPos { col: 2, row: 1 });
+        let screenshot =
+            build_screenshot(b"\x1b[31mhello\x1b[0m", 4, 20, None, 14.0, cursor, true).unwrap();
         let png = screenshot.to_png().unwrap();
         assert!(png.starts_with(b"\x89PNG\r\n\x1a\n"));
     }

--- a/src/commands/screenshot.rs
+++ b/src/commands/screenshot.rs
@@ -127,7 +127,7 @@ fn build_screenshot(
     mouse_cursor: Option<crate::daemon::protocol::CursorPos>,
     mouse_held: bool,
 ) -> Result<Screenshot> {
-    let mut parser = vt100::Parser::new(rows, cols, 0);
+    let mut parser = crate::emu::Parser::new(rows, cols, 0);
     parser.process(ansi_bytes);
 
     let screen = ScreenSnapshot::from_vt100(parser.screen());

--- a/src/commands/usage.rs
+++ b/src/commands/usage.rs
@@ -4,35 +4,36 @@ pub async fn run() {
 
 Spawn terminal apps, read the screen, send keystrokes. No GUI needed.
 Default terminal size: 120x40 (TERM=xterm-256color).
-All commands target the "default" session unless --name is given.
+
+Almost every command takes `--name <s>` to pick a session (default: "default").
+Omitted from the lines below to keep the cheatsheet tight.
 
 COMMANDS:
   run <cmd> [args...]             Spawn a process in a new virtual terminal
-    --name <s>                      Session name (default: "default")
     --size <CxR>                    Terminal size (default: 120x40)
     --scrollback <n>                Scrollback lines (default: 1000)
     --env KEY=VAL                   Extra env vars (repeatable)
     --cwd <path>                    Working directory
     --term <TERM>                   TERM value (default: xterm-256color)
     --shell                         Wrap in $SHELL -c "..."
-  kill [--name <s>]               Kill process and remove session
+  kill                            Kill process and remove session
   list                            List active sessions
-  status [--name <s>]             Session info: pid, alive/exited, exit code, size
+  status                          Session info: pid, alive/exited, exit code, size
 
-  screenshot [--name <s>]         Capture the terminal screen as text
+  screenshot                      Capture the terminal screen as text
     --png                           Render as a PNG image instead of text
     --output <file>                 Output file path (default: auto temp file)
     --stdout                        Write PNG bytes to stdout (with --png)
     --font <path>                   Optional TTF font file (bundled: JetBrains Mono)
     --font-size <px>                Font size in pixels (default: 14, with --png)
     --no-cursor                     Suppress the magenta △ overlay (with --png)
-  cursor [--name <s>]             Print cursor position as row,col
-  scrollback [--name <s>]         Print scrollback buffer
+  cursor                          Print cursor position as row,col
+  scrollback                      Print scrollback buffer
     --lines <n>                     How many lines (default: all)
 
-  type <text> [--name <s>]        Type literal text
-  press <key>... [--name <s>]     Send keystrokes (space-separated)
-  paste <text> [--name <s>]       Bracketed paste
+  type <text>                     Type literal text
+  press <key>...                  Send keystrokes (space-separated)
+  paste <text>                    Bracketed paste
 
   mouse click <col> <row>         Click at column,row (0-based, like cursor)
     --button left|right|middle      Default: left
@@ -46,7 +47,7 @@ COMMANDS:
   mouse move <col> <row>          Move cursor to col,row
   mouse drag <c1> <r1> <c2> <r2>  Drag from (c1,r1) to (c2,r2)
   mouse scroll up|down|left|right [<col> <row>] [--amount N]
-  mouse state [--name <s>]        Print mouse status (or "disabled")
+  mouse state                     Print mouse status (or "disabled")
 
 MOUSE CURSOR DISPLAY:
   When tu has a synthetic mouse cursor it shows up as a magenta △ glyph
@@ -65,13 +66,13 @@ MOUSE TARGETING:
   Run `tu mouse state` first to check the app accepts mouse input. If it
   doesn't, the click errors out — pass --force to send the bytes anyway.
 
-  resize <CxR> [--name <s>]      Resize terminal (e.g. 160x50)
-  wait [--name <s>]               Wait for a condition
+  resize <CxR>                    Resize terminal (e.g. 160x50)
+  wait                            Wait for a condition
     --stable <ms>                   Screen unchanged for N ms
     --text <regex>                  Regex matches screen content
     --timeout <ms>                  Max wait (default: 5000)
 
-  monitor [--name <s>]            Live read-only view of a session (← → to switch)
+  monitor                         Live read-only view of a session (← → to switch)
   daemon start|stop|status        Manage background daemon
   self update [--check]          Update tu to the latest version
 
@@ -98,7 +99,7 @@ EXAMPLES:
   tu press Escape : w q Enter          Save and quit vim
   tu type "hello world"                Type text into the terminal
   tu wait --text "Complete" --timeout 10000
-  tu mouse state                       → mode=ButtonMotion encoding=Sgr
+  tu mouse state                       Show mouse status + cursor + held buttons
   tu mouse click 50 20                 Left-click at (col=50, row=20)
   tu mouse click --on-text "OK"        Click the OK button by label
   tu mouse click --on-text "Buy" --clicks 2   Double-click on "Buy"

--- a/src/commands/usage.rs
+++ b/src/commands/usage.rs
@@ -43,11 +43,10 @@ COMMANDS:
     --match-index N                 Disambiguate when multiple matches (0-based)
     --force                         Send even if app has not enabled mouse mode
   mouse down|up <col> <row>       Press / release one half of a click
-  mouse move <col> <row>          Move cursor (always glides; wire events
-                                  emitted only if app has AnyMotion / 1003)
-  mouse drag <c1> <r1> <c2> <r2>  Atomic down → motion path → up
+  mouse move <col> <row>          Move cursor to col,row
+  mouse drag <c1> <r1> <c2> <r2>  Drag from (c1,r1) to (c2,r2)
   mouse scroll up|down|left|right [<col> <row>] [--amount N]
-  mouse state [--name <s>]        Print mouse mode + encoding (or "disabled")
+  mouse state [--name <s>]        Print mouse status (or "disabled")
 
 MOUSE CURSOR DISPLAY:
   When tu has a synthetic mouse cursor it shows up as a magenta △ glyph
@@ -63,14 +62,8 @@ MOUSE TARGETING:
   and click the center cell of the chosen match.
   Combine with --clicks for one-shot multi-click on a label:
     tu mouse click --on-text "Buy upgrade" --clicks 2
-  Run `tu mouse state` first to confirm the inner app has DECSET 1000/1002/1006.
-  If mode=None the click errors out — pass --force to send raw bytes anyway.
-
-MOUSE GLIDE:
-  click / down / up / move always interpolate from the current synthetic
-  cursor to the target — the cursor never teleports. Motion-aware apps
-  (AnyMotion / 1003) see real motion events; weaker modes get nothing on
-  the wire but the synthetic cursor still glides for the monitor's △.
+  Run `tu mouse state` first to check the app accepts mouse input. If it
+  doesn't, the click errors out — pass --force to send the bytes anyway.
 
   resize <CxR> [--name <s>]      Resize terminal (e.g. 160x50)
   wait [--name <s>]               Wait for a condition

--- a/src/commands/usage.rs
+++ b/src/commands/usage.rs
@@ -25,6 +25,7 @@ COMMANDS:
     --stdout                        Write PNG bytes to stdout (with --png)
     --font <path>                   Optional TTF font file (bundled: JetBrains Mono)
     --font-size <px>                Font size in pixels (default: 14, with --png)
+    --no-cursor                     Suppress the magenta △ overlay (with --png)
   cursor [--name <s>]             Print cursor position as row,col
   scrollback [--name <s>]         Print scrollback buffer
     --lines <n>                     How many lines (default: all)
@@ -42,7 +43,8 @@ COMMANDS:
     --match-index N                 Disambiguate when multiple matches (0-based)
     --force                         Send even if app has not enabled mouse mode
   mouse down|up <col> <row>       Press / release one half of a click
-  mouse move <col> <row>          Move cursor (needs ButtonMotion / AnyMotion)
+  mouse move <col> <row>          Move cursor (always glides; wire events
+                                  emitted only if app has AnyMotion / 1003)
   mouse drag <c1> <r1> <c2> <r2>  Atomic down → motion path → up
   mouse scroll up|down|left|right [<col> <row>] [--amount N]
   mouse state [--name <s>]        Print mouse mode + encoding (or "disabled")
@@ -63,6 +65,12 @@ MOUSE TARGETING:
     tu mouse click --on-text "Buy upgrade" --clicks 2
   Run `tu mouse state` first to confirm the inner app has DECSET 1000/1002/1006.
   If mode=None the click errors out — pass --force to send raw bytes anyway.
+
+MOUSE GLIDE:
+  click / down / up / move always interpolate from the current synthetic
+  cursor to the target — the cursor never teleports. Motion-aware apps
+  (AnyMotion / 1003) see real motion events; weaker modes get nothing on
+  the wire but the synthetic cursor still glides for the monitor's △.
 
   resize <CxR> [--name <s>]      Resize terminal (e.g. 160x50)
   wait [--name <s>]               Wait for a condition

--- a/src/commands/usage.rs
+++ b/src/commands/usage.rs
@@ -2,11 +2,10 @@ pub async fn run() {
     print!(
         r#"tu ("terminal-use") -- headless virtual terminal for AI agents
 
-Spawn terminal apps, read the screen, send keystrokes. No GUI needed.
-Default terminal size: 120x40 (TERM=xterm-256color).
+Spawn terminal apps, read the screen, send keystrokes, drive the mouse.
+No GUI needed. Default terminal size: 120x40 (TERM=xterm-256color).
 
 Almost every command takes `--name <s>` to pick a session (default: "default").
-Omitted from the lines below to keep the cheatsheet tight.
 
 COMMANDS:
   run <cmd> [args...]             Spawn a process in a new virtual terminal

--- a/src/commands/usage.rs
+++ b/src/commands/usage.rs
@@ -33,6 +33,29 @@ COMMANDS:
   press <key>... [--name <s>]     Send keystrokes (space-separated)
   paste <text> [--name <s>]       Bracketed paste
 
+  mouse click <col> <row>         Click at column,row (0-based, like cursor)
+    --button left|right|middle      Default: left
+    --mods Ctrl,Shift,Alt           Modifier combo (comma-separated)
+    --clicks N                      Multi-click (2 = double, 3 = triple)
+    --on-text <TEXT>                Click center of first text match instead
+    --on-regex <RE>                 Click center of first regex match
+    --match-index N                 Disambiguate when multiple matches (0-based)
+    --force                         Send even if app has not enabled mouse mode
+  mouse down|up <col> <row>       Press / release one half of a click
+  mouse move <col> <row>          Move cursor (needs ButtonMotion / AnyMotion)
+  mouse drag <c1> <r1> <c2> <r2>  Atomic down → motion path → up
+  mouse scroll up|down|left|right [<col> <row>] [--amount N]
+  mouse state [--name <s>]        Print mouse mode + encoding (or "disabled")
+
+MOUSE TARGETING:
+  Coords are 0-based and bounded by the current size; out-of-bounds errors out.
+  --on-text / --on-regex search the visible screen left-to-right, top-to-bottom
+  and click the center cell of the chosen match.
+  Combine with --clicks for one-shot multi-click on a label:
+    tu mouse click --on-text "Buy upgrade" --clicks 2
+  Run `tu mouse state` first to confirm the inner app has DECSET 1000/1002/1006.
+  If mode=None the click errors out — pass --force to send raw bytes anyway.
+
   resize <CxR> [--name <s>]      Resize terminal (e.g. 160x50)
   wait [--name <s>]               Wait for a condition
     --stable <ms>                   Screen unchanged for N ms
@@ -66,6 +89,13 @@ EXAMPLES:
   tu press Escape : w q Enter          Save and quit vim
   tu type "hello world"                Type text into the terminal
   tu wait --text "Complete" --timeout 10000
+  tu mouse state                       → mode=ButtonMotion encoding=Sgr
+  tu mouse click 50 20                 Left-click at (col=50, row=20)
+  tu mouse click --on-text "OK"        Click the OK button by label
+  tu mouse click --on-text "Buy" --clicks 2   Double-click on "Buy"
+  tu mouse click 10 5 --mods Ctrl      Ctrl+Click at (10,5)
+  tu mouse drag 10 10 50 20            Drag from (10,10) to (50,20)
+  tu mouse scroll down --amount 5      Scroll wheel down 5 ticks
   tu monitor                           Watch the session live
   tu kill                              End session
 "#

--- a/src/commands/usage.rs
+++ b/src/commands/usage.rs
@@ -47,6 +47,14 @@ COMMANDS:
   mouse scroll up|down|left|right [<col> <row>] [--amount N]
   mouse state [--name <s>]        Print mouse mode + encoding (or "disabled")
 
+MOUSE CURSOR DISPLAY:
+  When tu has a synthetic mouse cursor it shows up as a magenta △ glyph
+  (filled magenta cell when a button is held) — visible in `tu monitor`
+  and in `tu screenshot --png`. Text screenshots keep the body verbatim
+  and append `△ tu mouse cursor at (col,row)` as a trailer below the
+  rendered grid (so regex / grep over the body is never corrupted).
+  `tu mouse state` is the canonical machine-readable source.
+
 MOUSE TARGETING:
   Coords are 0-based and bounded by the current size; out-of-bounds errors out.
   --on-text / --on-regex search the visible screen left-to-right, top-to-bottom

--- a/src/commands/usage.rs
+++ b/src/commands/usage.rs
@@ -48,23 +48,6 @@ COMMANDS:
   mouse scroll up|down|left|right [<col> <row>] [--amount N]
   mouse state                     Print mouse status (or "disabled")
 
-MOUSE CURSOR DISPLAY:
-  When tu has a synthetic mouse cursor it shows up as a magenta △ glyph
-  (filled magenta cell when a button is held) — visible in `tu monitor`
-  and in `tu screenshot --png`. Text screenshots keep the body verbatim
-  and append `△ tu mouse cursor at (col,row)` as a trailer below the
-  rendered grid (so regex / grep over the body is never corrupted).
-  `tu mouse state` is the canonical machine-readable source.
-
-MOUSE TARGETING:
-  Coords are 0-based and bounded by the current size; out-of-bounds errors out.
-  --on-text / --on-regex search the visible screen left-to-right, top-to-bottom
-  and click the center cell of the chosen match.
-  Combine with --clicks for one-shot multi-click on a label:
-    tu mouse click --on-text "Buy upgrade" --clicks 2
-  Run `tu mouse state` first to check the app accepts mouse input. If it
-  doesn't, the click errors out — pass --force to send the bytes anyway.
-
   resize <CxR>                    Resize terminal (e.g. 160x50)
   wait                            Wait for a condition
     --stable <ms>                   Screen unchanged for N ms
@@ -74,6 +57,22 @@ MOUSE TARGETING:
   monitor                         Live read-only view of a session (← → to switch)
   daemon start|stop|status        Manage background daemon
   self update [--check]          Update tu to the latest version
+
+MOUSE CURSOR DISPLAY:
+  tu's virtual mouse cursor renders as a magenta △ (filled magenta cell when
+  a button is held) in `tu monitor` and in `tu screenshot --png`. Text
+  screenshots keep the body untouched and append `△ tu mouse cursor at
+  (col,row)` as a trailer below the grid. `tu mouse state` is the
+  machine-readable source.
+
+MOUSE TARGETING:
+  Coords are 0-based and bounded by the current size; out-of-bounds errors out.
+  --on-text / --on-regex search the visible screen left-to-right, top-to-bottom
+  and click the center cell of the chosen match.
+  Combine with --clicks for one-shot multi-click on a label:
+    tu mouse click --on-text "Buy upgrade" --clicks 2
+  Run `tu mouse state` first to check the app accepts mouse input. If it
+  doesn't, the click errors out — pass --force to send the bytes anyway.
 
 KEYS:
   Letters/symbols    a, Z, !, @            Modifiers       Ctrl+C, Alt+F, Shift+Tab

--- a/src/daemon/manager.rs
+++ b/src/daemon/manager.rs
@@ -401,7 +401,10 @@ pub async fn handle_mouse_glided(
     // fd here so we can write to the PTY between manager-lock acquisitions
     // without keeping a session reference alive.
     let snapshot = {
-        let mgr = manager.lock().await;
+        let mut mgr = manager.lock().await;
+        // Reset the idle timer so a long stream of mouse activity (drag,
+        // scroll, click sequences) doesn't let the daemon time out.
+        mgr.touch();
         let Some(session) = mgr.sessions.get(&name) else {
             return Response::Error {
                 message: format!("Session {name:?} not found"),
@@ -423,26 +426,11 @@ pub async fn handle_mouse_glided(
         let (mode, encoding, screen_rows) = {
             let p = parser.lock().await;
             let screen = p.screen();
-            let mode = vt_mode_to_proto(screen.mouse_protocol_mode());
-            let enc = vt_encoding_to_proto(screen.mouse_protocol_encoding());
-            let mut text_rows = Vec::with_capacity(rows as usize);
-            for r in 0..rows {
-                let mut line = String::new();
-                for c in 0..cols {
-                    let cell = screen.cell(r, c).unwrap();
-                    if cell.is_wide_continuation() {
-                        continue;
-                    }
-                    let ch = cell.contents();
-                    if ch.is_empty() {
-                        line.push(' ');
-                    } else {
-                        line.push_str(ch);
-                    }
-                }
-                text_rows.push(line);
-            }
-            (mode, enc, text_rows)
+            (
+                vt_mode_to_proto(screen.mouse_protocol_mode()),
+                vt_encoding_to_proto(screen.mouse_protocol_encoding()),
+                screen.text_rows(),
+            )
         };
         Snapshot {
             master_fd,
@@ -803,7 +791,6 @@ fn now_unix() -> u64 {
 fn vt_mode_to_proto(mode: crate::emu::MouseProtocolMode) -> MouseMode {
     match mode {
         crate::emu::MouseProtocolMode::None => MouseMode::None,
-        crate::emu::MouseProtocolMode::Press => MouseMode::Press,
         crate::emu::MouseProtocolMode::PressRelease => MouseMode::PressRelease,
         crate::emu::MouseProtocolMode::ButtonMotion => MouseMode::ButtonMotion,
         crate::emu::MouseProtocolMode::AnyMotion => MouseMode::AnyMotion,
@@ -898,10 +885,7 @@ where
             });
         }
         Move { target, mods } => {
-            if matches!(
-                mode,
-                MouseMode::None | MouseMode::Press | MouseMode::PressRelease
-            ) {
+            if matches!(mode, MouseMode::None | MouseMode::PressRelease) {
                 return Err(format!(
                     "mouse mode {mode:?} does not report bare motion (need ButtonMotion or AnyMotion)"
                 ));

--- a/src/daemon/manager.rs
+++ b/src/daemon/manager.rs
@@ -5,8 +5,8 @@ use tokio::sync::Mutex;
 use tokio::time::{Duration, Instant};
 
 use crate::daemon::protocol::{
-    MouseAction, MouseEncoding, MouseEventKind, MouseLastEvent, MouseMode, MouseTarget, Request,
-    Response, SessionInfo, TermSize,
+    MouseAction, MouseButton, MouseEncoding, MouseEventKind, MouseLastEvent, MouseMode, MouseMods,
+    MouseTarget, Request, Response, SessionInfo, TermSize,
 };
 use crate::daemon::session::Session;
 use crate::mouse::{self, WireEvent};
@@ -66,16 +66,13 @@ impl SessionManager {
 
             Request::Resize { name, size } => self.handle_resize(&name, size).await,
 
-            Request::Mouse {
-                name,
-                action,
-                force,
-            } => self.handle_mouse(&name, action, force).await,
-
             Request::MouseState { name } => self.handle_mouse_state(&name).await,
 
-            // Wait is handled directly in server.rs to avoid holding the manager lock
+            // Wait and Mouse are handled in server.rs without the manager lock —
+            // Wait polls for seconds, Mouse paces interpolated motion events
+            // with sleeps so the synthetic cursor visibly glides on monitor.
             Request::Wait { .. } => unreachable!("Wait should be handled in server.rs"),
+            Request::Mouse { .. } => unreachable!("Mouse should be handled in server.rs"),
 
             Request::Shutdown => {
                 // Kill all sessions
@@ -377,25 +374,55 @@ impl SessionManager {
             },
         }
     }
+}
 
-    async fn handle_mouse(&mut self, name: &str, action: MouseAction, force: bool) -> Response {
-        let session = match self.sessions.get_mut(name) {
-            Some(s) => s,
-            None => {
+/// Process a Mouse request without holding the manager lock for the whole
+/// command. Click / Down / Up / Move *interpolate* a path of motion events
+/// from the synthetic cursor's current position to the target — paced with
+/// short sleeps so monitor's `△` glides instead of teleporting and the inner
+/// app sees a real-mouse-style stream of motion events.
+///
+/// Drag continues to interpolate its own from→to segment internally, after
+/// gliding cur→from. Scroll is position-independent and skips the glide.
+///
+/// The manager lock is taken briefly at start (snapshot session refs) and
+/// briefly per emit (tracker update). Between emits the lock is released so
+/// monitor's `ScreenshotCells` polls can interleave and pick up each
+/// intermediate cursor position.
+pub async fn handle_mouse_glided(
+    manager: &Mutex<SessionManager>,
+    name: String,
+    action: MouseAction,
+    force: bool,
+) -> Response {
+    use std::os::fd::OwnedFd;
+
+    // Step 1: snapshot session state under one brief lock. We dup the master
+    // fd here so we can write to the PTY between manager-lock acquisitions
+    // without keeping a session reference alive.
+    let snapshot = {
+        let mgr = manager.lock().await;
+        let Some(session) = mgr.sessions.get(&name) else {
+            return Response::Error {
+                message: format!("Session {name:?} not found"),
+            };
+        };
+        let parser = session.parser.clone();
+        let cols = session.size.cols;
+        let rows = session.size.rows;
+        let cur_pos = session.mouse.cursor;
+        let buttons_held: Vec<MouseButton> = session.mouse.buttons_held.clone();
+        let master_fd: OwnedFd = match nix::unistd::dup(&session.master_fd) {
+            Ok(fd) => fd,
+            Err(e) => {
                 return Response::Error {
-                    message: format!("Session {name:?} not found"),
+                    message: format!("dup master_fd: {e}"),
                 }
             }
         };
-
-        let cols = session.size.cols;
-        let rows = session.size.rows;
-
-        // Snapshot mouse mode/encoding and the rendered screen text under one lock
-        // so we can resolve text targets without races.
         let (mode, encoding, screen_rows) = {
-            let parser = session.parser.lock().await;
-            let screen = parser.screen();
+            let p = parser.lock().await;
+            let screen = p.screen();
             let mode = vt_mode_to_proto(screen.mouse_protocol_mode());
             let enc = vt_encoding_to_proto(screen.mouse_protocol_encoding());
             let mut text_rows = Vec::with_capacity(rows as usize);
@@ -417,70 +444,260 @@ impl SessionManager {
             }
             (mode, enc, text_rows)
         };
-
-        if !force && mode == MouseMode::None {
-            return Response::Error {
-                message: format!(
-                    "session {name:?} has not enabled mouse reporting (DECSET 1000/1002/1006). \
-                     Use --force to send raw bytes anyway."
-                ),
-            };
+        Snapshot {
+            master_fd,
+            cols,
+            rows,
+            cur_pos: cur_pos.map(|p| (p.col, p.row)),
+            buttons_held,
+            mode,
+            encoding,
+            screen_rows,
         }
+    };
 
-        // Resolve targets to coordinates.
-        let resolve = |target: &MouseTarget| -> Result<(u16, u16), String> {
-            match target {
-                MouseTarget::Coords { col, row } => {
-                    if *col >= cols || *row >= rows {
-                        return Err(format!(
-                            "coords ({col},{row}) out of bounds (terminal is {cols}x{rows})"
-                        ));
-                    }
-                    Ok((*col, *row))
-                }
-                MouseTarget::Text {
-                    needle,
-                    match_index,
-                } => {
-                    let hits = mouse::find_text(&screen_rows, needle);
-                    pick_match(&hits, *match_index, &format!("text {needle:?}"))
-                }
-                MouseTarget::Regex {
-                    pattern,
-                    match_index,
-                } => {
-                    let hits = match mouse::find_regex(&screen_rows, pattern) {
-                        Ok(h) => h,
-                        Err(e) => return Err(e.to_string()),
-                    };
-                    pick_match(&hits, *match_index, &format!("regex {pattern:?}"))
-                }
-            }
+    let Snapshot {
+        master_fd,
+        cols,
+        rows,
+        cur_pos,
+        buttons_held,
+        mode,
+        encoding,
+        screen_rows,
+    } = snapshot;
+
+    if !force && mode == MouseMode::None {
+        return Response::Error {
+            message: format!(
+                "session {name:?} has not enabled mouse reporting (DECSET 1000/1002/1006). \
+                 Use --force to send raw bytes anyway."
+            ),
         };
+    }
 
-        let events = match build_events(&action, &resolve, mode) {
-            Ok(evs) => evs,
+    // Resolve targets to coordinates against the snapshotted screen text.
+    let resolve = |target: &MouseTarget| -> Result<(u16, u16), String> {
+        match target {
+            MouseTarget::Coords { col, row } => {
+                if *col >= cols || *row >= rows {
+                    return Err(format!(
+                        "coords ({col},{row}) out of bounds (terminal is {cols}x{rows})"
+                    ));
+                }
+                Ok((*col, *row))
+            }
+            MouseTarget::Text {
+                needle,
+                match_index,
+            } => {
+                let hits = mouse::find_text(&screen_rows, needle);
+                pick_match(&hits, *match_index, &format!("text {needle:?}"))
+            }
+            MouseTarget::Regex {
+                pattern,
+                match_index,
+            } => {
+                let hits = match mouse::find_regex(&screen_rows, pattern) {
+                    Ok(h) => h,
+                    Err(e) => return Err(e.to_string()),
+                };
+                pick_match(&hits, *match_index, &format!("regex {pattern:?}"))
+            }
+        }
+    };
+
+    // Where should the synthetic cursor land BEFORE the action's own events?
+    // For most actions: at the action's target. For Drag: at its `from`.
+    // Scroll is position-independent so no pre-glide.
+    let glide_target: Option<(u16, u16)> = match &action {
+        MouseAction::Click { target, .. }
+        | MouseAction::Down { target, .. }
+        | MouseAction::Up { target, .. }
+        | MouseAction::Move { target, .. } => match resolve(target) {
+            Ok(p) => Some(p),
             Err(e) => return Response::Error { message: e },
+        },
+        MouseAction::Drag { from, .. } => match resolve(from) {
+            Ok(p) => Some(p),
+            Err(e) => return Response::Error { message: e },
+        },
+        MouseAction::Scroll { .. } => None,
+    };
+
+    // Run the glide if we have both a starting cursor and a destination.
+    if let (Some(start), Some(end)) = (cur_pos, glide_target) {
+        if start != end {
+            let path = full_path_inclusive(start.0, start.1, end.0, end.1);
+            // Skip the very first cell — that's where the cursor already sits.
+            // Include the destination cell so the cursor visibly arrives.
+            glide_cells(
+                manager,
+                &name,
+                &master_fd,
+                &path[1..],
+                &buttons_held,
+                mode,
+                encoding,
+            )
+            .await;
+        }
+    } else if cur_pos.is_none() {
+        // First-ever positional command: no glide, but we still want the
+        // cursor to land at the action's target. Skipping glide is fine —
+        // the action's own events will set the position.
+    }
+
+    // Now emit the action's own events (possibly Drag's interpolated segment,
+    // or Click's Down + Up at target, etc.). For Move there are no extra
+    // events: glide_cells already deposited the final Move at the destination.
+    if matches!(action, MouseAction::Move { .. }) {
+        return Response::Ok;
+    }
+
+    let events = match build_events(&action, &resolve, mode) {
+        Ok(evs) => evs,
+        Err(e) => return Response::Error { message: e },
+    };
+
+    let bytes = match mouse::encode(&events, encoding) {
+        Ok(b) => b,
+        Err(e) => {
+            return Response::Error {
+                message: format!("encode mouse events: {e}"),
+            }
+        }
+    };
+
+    if let Err(e) = crate::pty::input::write_to_pty(&master_fd, &bytes) {
+        return Response::Error {
+            message: format!("Mouse write failed: {e}"),
+        };
+    }
+
+    // Commit tracker update for the action's events.
+    {
+        let mut mgr = manager.lock().await;
+        if let Some(s) = mgr.sessions.get_mut(&name) {
+            update_tracker(&mut s.mouse, &events);
+        }
+    }
+
+    Response::Ok
+}
+
+struct Snapshot {
+    master_fd: std::os::fd::OwnedFd,
+    cols: u16,
+    rows: u16,
+    cur_pos: Option<(u16, u16)>,
+    buttons_held: Vec<MouseButton>,
+    mode: MouseMode,
+    encoding: MouseEncoding,
+    screen_rows: Vec<String>,
+}
+
+/// All cells along a Bresenham-like path from `(c1,r1)` to `(c2,r2)`,
+/// inclusive of both endpoints.
+fn full_path_inclusive(c1: u16, r1: u16, c2: u16, r2: u16) -> Vec<(u16, u16)> {
+    let dx = (c2 as i32 - c1 as i32).abs();
+    let dy = (r2 as i32 - r1 as i32).abs();
+    let steps = dx.max(dy);
+    if steps == 0 {
+        return vec![(c1, r1)];
+    }
+    let mut out = Vec::with_capacity((steps + 1) as usize);
+    for i in 0..=steps {
+        let t = i as f64 / steps as f64;
+        let col = (c1 as f64 + (c2 as f64 - c1 as f64) * t).round() as u16;
+        let row = (r1 as f64 + (r2 as f64 - r1 as f64) * t).round() as u16;
+        out.push((col, row));
+    }
+    out
+}
+
+/// Pace through a sequence of cells, emitting motion events on the wire (when
+/// the inner app's mouse mode supports it) and updating the per-session
+/// cursor tracker so `tu monitor` sees the synthetic cursor glide.
+///
+/// Bare motion (`Move`) is emitted on the wire only when the inner app has
+/// `AnyMotion` (DECSET 1003). With `ButtonMotion` (1002), motion is reported
+/// only when a button is held — which is the case if `buttons_held` is
+/// non-empty (e.g. a glide before a `mouse up` after a prior `mouse down`).
+/// In modes that don't report motion at all the wire emission is skipped, but
+/// the tracker still updates so the synthetic cursor still glides visually.
+async fn glide_cells(
+    manager: &Mutex<SessionManager>,
+    name: &str,
+    master_fd: &std::os::fd::OwnedFd,
+    cells: &[(u16, u16)],
+    buttons_held: &[MouseButton],
+    mode: MouseMode,
+    encoding: MouseEncoding,
+) {
+    if cells.is_empty() {
+        return;
+    }
+    // Sleep budget: ~6ms per cell, capped at 250ms total. Short enough that
+    // even a corner-to-corner glide finishes before the user's next command,
+    // long enough to be visibly fluid at 30fps.
+    let target_ms: u64 = ((cells.len() as u64) * 6).min(250);
+    let per_cell = Duration::from_millis((target_ms / cells.len() as u64).max(1));
+
+    let drag_button = buttons_held.first().copied();
+    let mods = MouseMods::default();
+
+    for &(col, row) in cells {
+        // Build the per-cell wire event (if the app's mode reports it).
+        let wire_event: Option<WireEvent> = match (mode, drag_button) {
+            (MouseMode::AnyMotion, Some(button)) => Some(WireEvent::DragMove {
+                col,
+                row,
+                button,
+                mods,
+            }),
+            (MouseMode::AnyMotion, None) => Some(WireEvent::Move { col, row, mods }),
+            (MouseMode::ButtonMotion, Some(button)) => Some(WireEvent::DragMove {
+                col,
+                row,
+                button,
+                mods,
+            }),
+            // ButtonMotion without a held button, or PressRelease/Press/None:
+            // the app doesn't expect motion here. Skip wire emission but still
+            // update the synthetic-cursor tracker so monitor glides.
+            _ => None,
         };
 
-        let bytes = match mouse::encode(&events, encoding) {
-            Ok(b) => b,
-            Err(e) => {
-                return Response::Error {
-                    message: format!("encode mouse events: {e}"),
+        if let Some(ev) = wire_event {
+            if let Ok(bytes) = mouse::encode(&[ev], encoding) {
+                let _ = crate::pty::input::write_to_pty(master_fd, &bytes);
+            }
+        }
+
+        {
+            let mut mgr = manager.lock().await;
+            if let Some(s) = mgr.sessions.get_mut(name) {
+                s.mouse.record_position(col, row);
+                if let Some(ev) = wire_event {
+                    s.mouse.last_event = Some(MouseLastEvent {
+                        kind: match ev {
+                            WireEvent::DragMove { .. } => MouseEventKind::DragMove,
+                            WireEvent::Move { .. } => MouseEventKind::Move,
+                            _ => MouseEventKind::Move,
+                        },
+                        col,
+                        row,
+                        button: drag_button,
+                        scroll_dir: None,
+                        mods,
+                        ts_unix: now_unix(),
+                    });
                 }
             }
-        };
-
-        match session.write_bytes(&bytes) {
-            Ok(()) => {
-                update_tracker(&mut session.mouse, &events);
-                Response::Ok
-            }
-            Err(e) => Response::Error {
-                message: format!("Mouse write failed: {e}"),
-            },
         }
+
+        tokio::time::sleep(per_cell).await;
     }
 }
 

--- a/src/daemon/manager.rs
+++ b/src/daemon/manager.rs
@@ -5,7 +5,8 @@ use tokio::sync::Mutex;
 use tokio::time::{Duration, Instant};
 
 use crate::daemon::protocol::{
-    MouseAction, MouseEncoding, MouseMode, MouseTarget, Request, Response, SessionInfo, TermSize,
+    MouseAction, MouseEncoding, MouseEventKind, MouseLastEvent, MouseMode, MouseTarget, Request,
+    Response, SessionInfo, TermSize,
 };
 use crate::daemon::session::Session;
 use crate::mouse::{self, WireEvent};
@@ -356,6 +357,10 @@ impl SessionManager {
                 Response::MouseState {
                     mode: vt_mode_to_proto(screen.mouse_protocol_mode()),
                     encoding: vt_encoding_to_proto(screen.mouse_protocol_encoding()),
+                    size: session.size.clone(),
+                    cursor: session.mouse.cursor,
+                    buttons_held: session.mouse.buttons_held.clone(),
+                    last_event: session.mouse.last_event.clone(),
                 }
             }
             None => Response::Error {
@@ -365,7 +370,7 @@ impl SessionManager {
     }
 
     async fn handle_mouse(&mut self, name: &str, action: MouseAction, force: bool) -> Response {
-        let session = match self.sessions.get(name) {
+        let session = match self.sessions.get_mut(name) {
             Some(s) => s,
             None => {
                 return Response::Error {
@@ -459,12 +464,114 @@ impl SessionManager {
         };
 
         match session.write_bytes(&bytes) {
-            Ok(()) => Response::Ok,
+            Ok(()) => {
+                update_tracker(&mut session.mouse, &events);
+                Response::Ok
+            }
             Err(e) => Response::Error {
                 message: format!("Mouse write failed: {e}"),
             },
         }
     }
+}
+
+fn update_tracker(tracker: &mut crate::daemon::session::MouseTracker, events: &[WireEvent]) {
+    for ev in events {
+        match *ev {
+            WireEvent::Down {
+                col,
+                row,
+                button,
+                mods,
+            } => {
+                tracker.record_position(col, row);
+                tracker.press(button);
+                tracker.last_event = Some(MouseLastEvent {
+                    kind: MouseEventKind::Down,
+                    col,
+                    row,
+                    button: Some(button),
+                    scroll_dir: None,
+                    mods,
+                    ts_unix: now_unix(),
+                });
+            }
+            WireEvent::Up {
+                col,
+                row,
+                button,
+                mods,
+            } => {
+                tracker.record_position(col, row);
+                tracker.release(button);
+                tracker.last_event = Some(MouseLastEvent {
+                    kind: MouseEventKind::Up,
+                    col,
+                    row,
+                    button: Some(button),
+                    scroll_dir: None,
+                    mods,
+                    ts_unix: now_unix(),
+                });
+            }
+            WireEvent::Move { col, row, mods } => {
+                tracker.record_position(col, row);
+                tracker.last_event = Some(MouseLastEvent {
+                    kind: MouseEventKind::Move,
+                    col,
+                    row,
+                    button: None,
+                    scroll_dir: None,
+                    mods,
+                    ts_unix: now_unix(),
+                });
+            }
+            WireEvent::DragMove {
+                col,
+                row,
+                button,
+                mods,
+            } => {
+                tracker.record_position(col, row);
+                tracker.last_event = Some(MouseLastEvent {
+                    kind: MouseEventKind::DragMove,
+                    col,
+                    row,
+                    button: Some(button),
+                    scroll_dir: None,
+                    mods,
+                    ts_unix: now_unix(),
+                });
+            }
+            WireEvent::Scroll {
+                col,
+                row,
+                dir,
+                mods,
+            } => {
+                // Scroll is position-independent in the agent's mental model;
+                // don't move the synthetic cursor. last_event still records
+                // the coords that went on the wire.
+                tracker.last_event = Some(MouseLastEvent {
+                    kind: MouseEventKind::Scroll,
+                    col,
+                    row,
+                    button: None,
+                    scroll_dir: Some(dir),
+                    mods,
+                    ts_unix: now_unix(),
+                });
+            }
+        }
+    }
+}
+
+fn now_unix() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
 }
 
 fn vt_mode_to_proto(mode: vt100::MouseProtocolMode) -> MouseMode {
@@ -754,6 +861,167 @@ mod tests {
     fn interpolate_short_emits_nothing() {
         assert!(interpolate_path(0, 0, 1, 0).is_empty());
         assert!(interpolate_path(0, 0, 0, 0).is_empty());
+    }
+
+    fn ev_down(col: u16, row: u16, button: MouseButton) -> WireEvent {
+        WireEvent::Down {
+            col,
+            row,
+            button,
+            mods: Default::default(),
+        }
+    }
+    fn ev_up(col: u16, row: u16, button: MouseButton) -> WireEvent {
+        WireEvent::Up {
+            col,
+            row,
+            button,
+            mods: Default::default(),
+        }
+    }
+
+    #[test]
+    fn tracker_down_records_position_and_held_button() {
+        let mut t = crate::daemon::session::MouseTracker::default();
+        update_tracker(&mut t, &[ev_down(10, 5, MouseButton::Left)]);
+        assert_eq!(
+            t.cursor,
+            Some(crate::daemon::protocol::CursorPos { row: 5, col: 10 })
+        );
+        assert_eq!(t.buttons_held, vec![MouseButton::Left]);
+        let last = t.last_event.as_ref().unwrap();
+        assert_eq!(last.kind, MouseEventKind::Down);
+        assert_eq!(last.col, 10);
+        assert_eq!(last.row, 5);
+    }
+
+    #[test]
+    fn tracker_up_releases_button_keeps_cursor() {
+        let mut t = crate::daemon::session::MouseTracker::default();
+        update_tracker(
+            &mut t,
+            &[
+                ev_down(10, 5, MouseButton::Left),
+                ev_up(11, 5, MouseButton::Left),
+            ],
+        );
+        assert!(t.buttons_held.is_empty());
+        assert_eq!(
+            t.cursor,
+            Some(crate::daemon::protocol::CursorPos { row: 5, col: 11 })
+        );
+    }
+
+    #[test]
+    fn tracker_click_leaves_no_held_buttons() {
+        let mut t = crate::daemon::session::MouseTracker::default();
+        update_tracker(
+            &mut t,
+            &[
+                ev_down(0, 0, MouseButton::Left),
+                ev_up(0, 0, MouseButton::Left),
+            ],
+        );
+        assert!(t.buttons_held.is_empty());
+    }
+
+    #[test]
+    fn tracker_drag_ends_clean() {
+        let mut t = crate::daemon::session::MouseTracker::default();
+        let evs = vec![
+            ev_down(0, 0, MouseButton::Left),
+            WireEvent::DragMove {
+                col: 1,
+                row: 0,
+                button: MouseButton::Left,
+                mods: Default::default(),
+            },
+            WireEvent::DragMove {
+                col: 2,
+                row: 0,
+                button: MouseButton::Left,
+                mods: Default::default(),
+            },
+            ev_up(3, 0, MouseButton::Left),
+        ];
+        update_tracker(&mut t, &evs);
+        assert!(t.buttons_held.is_empty());
+        assert_eq!(
+            t.cursor,
+            Some(crate::daemon::protocol::CursorPos { row: 0, col: 3 })
+        );
+        let last = t.last_event.as_ref().unwrap();
+        assert_eq!(last.kind, MouseEventKind::Up);
+    }
+
+    #[test]
+    fn tracker_two_buttons_held_in_order() {
+        let mut t = crate::daemon::session::MouseTracker::default();
+        update_tracker(
+            &mut t,
+            &[
+                ev_down(0, 0, MouseButton::Left),
+                ev_down(0, 0, MouseButton::Right),
+            ],
+        );
+        assert_eq!(t.buttons_held, vec![MouseButton::Left, MouseButton::Right]);
+        update_tracker(&mut t, &[ev_up(0, 0, MouseButton::Left)]);
+        assert_eq!(t.buttons_held, vec![MouseButton::Right]);
+    }
+
+    #[test]
+    fn tracker_double_down_does_not_dup() {
+        let mut t = crate::daemon::session::MouseTracker::default();
+        update_tracker(
+            &mut t,
+            &[
+                ev_down(0, 0, MouseButton::Left),
+                ev_down(1, 0, MouseButton::Left),
+            ],
+        );
+        assert_eq!(t.buttons_held, vec![MouseButton::Left]);
+    }
+
+    #[test]
+    fn tracker_scroll_does_not_move_cursor() {
+        let mut t = crate::daemon::session::MouseTracker::default();
+        update_tracker(&mut t, &[ev_down(20, 10, MouseButton::Left)]);
+        update_tracker(&mut t, &[ev_up(20, 10, MouseButton::Left)]);
+        let cursor_before = t.cursor;
+        update_tracker(
+            &mut t,
+            &[WireEvent::Scroll {
+                col: 0,
+                row: 0,
+                dir: ScrollDir::Down,
+                mods: Default::default(),
+            }],
+        );
+        assert_eq!(t.cursor, cursor_before);
+        assert_eq!(t.last_event.as_ref().unwrap().kind, MouseEventKind::Scroll);
+    }
+
+    #[test]
+    fn tracker_clamp_clears_cursor_when_out_of_bounds() {
+        let mut t = crate::daemon::session::MouseTracker {
+            cursor: Some(crate::daemon::protocol::CursorPos { row: 30, col: 90 }),
+            ..Default::default()
+        };
+        t.clamp_to_size(&TermSize { cols: 80, rows: 24 });
+        assert!(t.cursor.is_none());
+    }
+
+    #[test]
+    fn tracker_clamp_keeps_cursor_when_in_bounds() {
+        let mut t = crate::daemon::session::MouseTracker {
+            cursor: Some(crate::daemon::protocol::CursorPos { row: 10, col: 50 }),
+            ..Default::default()
+        };
+        t.clamp_to_size(&TermSize { cols: 80, rows: 24 });
+        assert_eq!(
+            t.cursor,
+            Some(crate::daemon::protocol::CursorPos { row: 10, col: 50 })
+        );
     }
 
     #[test]

--- a/src/daemon/manager.rs
+++ b/src/daemon/manager.rs
@@ -108,7 +108,10 @@ impl SessionManager {
     /// Get a clone of the session's vt100 parser and its terminal size.
     /// Used by the wait handler in server.rs to read screenshots without holding
     /// the manager lock.
-    pub fn get_session_parser(&self, name: &str) -> Option<(Arc<Mutex<vt100::Parser>>, TermSize)> {
+    pub fn get_session_parser(
+        &self,
+        name: &str,
+    ) -> Option<(Arc<Mutex<crate::emu::Parser>>, TermSize)> {
         self.sessions
             .get(name)
             .map(|s| (s.parser.clone(), s.size.clone()))
@@ -580,21 +583,21 @@ fn now_unix() -> u64 {
         .unwrap_or(0)
 }
 
-fn vt_mode_to_proto(mode: vt100::MouseProtocolMode) -> MouseMode {
+fn vt_mode_to_proto(mode: crate::emu::MouseProtocolMode) -> MouseMode {
     match mode {
-        vt100::MouseProtocolMode::None => MouseMode::None,
-        vt100::MouseProtocolMode::Press => MouseMode::Press,
-        vt100::MouseProtocolMode::PressRelease => MouseMode::PressRelease,
-        vt100::MouseProtocolMode::ButtonMotion => MouseMode::ButtonMotion,
-        vt100::MouseProtocolMode::AnyMotion => MouseMode::AnyMotion,
+        crate::emu::MouseProtocolMode::None => MouseMode::None,
+        crate::emu::MouseProtocolMode::Press => MouseMode::Press,
+        crate::emu::MouseProtocolMode::PressRelease => MouseMode::PressRelease,
+        crate::emu::MouseProtocolMode::ButtonMotion => MouseMode::ButtonMotion,
+        crate::emu::MouseProtocolMode::AnyMotion => MouseMode::AnyMotion,
     }
 }
 
-fn vt_encoding_to_proto(enc: vt100::MouseProtocolEncoding) -> MouseEncoding {
+fn vt_encoding_to_proto(enc: crate::emu::MouseProtocolEncoding) -> MouseEncoding {
     match enc {
-        vt100::MouseProtocolEncoding::Default => MouseEncoding::Default,
-        vt100::MouseProtocolEncoding::Utf8 => MouseEncoding::Utf8,
-        vt100::MouseProtocolEncoding::Sgr => MouseEncoding::Sgr,
+        crate::emu::MouseProtocolEncoding::Default => MouseEncoding::Default,
+        crate::emu::MouseProtocolEncoding::Utf8 => MouseEncoding::Utf8,
+        crate::emu::MouseProtocolEncoding::Sgr => MouseEncoding::Sgr,
     }
 }
 

--- a/src/daemon/manager.rs
+++ b/src/daemon/manager.rs
@@ -265,8 +265,6 @@ impl SessionManager {
                     rows_ansi,
                     rows: session.size.rows,
                     cols: session.size.cols,
-                    mouse_cursor: session.mouse.cursor,
-                    mouse_held: !session.mouse.buttons_held.is_empty(),
                 }
             }
             None => Response::Error {

--- a/src/daemon/manager.rs
+++ b/src/daemon/manager.rs
@@ -4,8 +4,11 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::time::{Duration, Instant};
 
-use crate::daemon::protocol::{Request, Response, SessionInfo, TermSize};
+use crate::daemon::protocol::{
+    MouseAction, MouseEncoding, MouseMode, MouseTarget, Request, Response, SessionInfo, TermSize,
+};
 use crate::daemon::session::Session;
+use crate::mouse::{self, WireEvent};
 
 /// Manages all terminal sessions.
 pub struct SessionManager {
@@ -61,6 +64,14 @@ impl SessionManager {
             Request::Paste { name, text } => self.handle_paste(&name, &text),
 
             Request::Resize { name, size } => self.handle_resize(&name, size).await,
+
+            Request::Mouse {
+                name,
+                action,
+                force,
+            } => self.handle_mouse(&name, action, force).await,
+
+            Request::MouseState { name } => self.handle_mouse_state(&name).await,
 
             // Wait is handled directly in server.rs to avoid holding the manager lock
             Request::Wait { .. } => unreachable!("Wait should be handled in server.rs"),
@@ -335,5 +346,433 @@ impl SessionManager {
                 message: format!("Session {name:?} not found"),
             },
         }
+    }
+
+    async fn handle_mouse_state(&self, name: &str) -> Response {
+        match self.sessions.get(name) {
+            Some(session) => {
+                let parser = session.parser.lock().await;
+                let screen = parser.screen();
+                Response::MouseState {
+                    mode: vt_mode_to_proto(screen.mouse_protocol_mode()),
+                    encoding: vt_encoding_to_proto(screen.mouse_protocol_encoding()),
+                }
+            }
+            None => Response::Error {
+                message: format!("Session {name:?} not found"),
+            },
+        }
+    }
+
+    async fn handle_mouse(&mut self, name: &str, action: MouseAction, force: bool) -> Response {
+        let session = match self.sessions.get(name) {
+            Some(s) => s,
+            None => {
+                return Response::Error {
+                    message: format!("Session {name:?} not found"),
+                }
+            }
+        };
+
+        let cols = session.size.cols;
+        let rows = session.size.rows;
+
+        // Snapshot mouse mode/encoding and the rendered screen text under one lock
+        // so we can resolve text targets without races.
+        let (mode, encoding, screen_rows) = {
+            let parser = session.parser.lock().await;
+            let screen = parser.screen();
+            let mode = vt_mode_to_proto(screen.mouse_protocol_mode());
+            let enc = vt_encoding_to_proto(screen.mouse_protocol_encoding());
+            let mut text_rows = Vec::with_capacity(rows as usize);
+            for r in 0..rows {
+                let mut line = String::new();
+                for c in 0..cols {
+                    let cell = screen.cell(r, c).unwrap();
+                    if cell.is_wide_continuation() {
+                        continue;
+                    }
+                    let ch = cell.contents();
+                    if ch.is_empty() {
+                        line.push(' ');
+                    } else {
+                        line.push_str(&ch);
+                    }
+                }
+                text_rows.push(line);
+            }
+            (mode, enc, text_rows)
+        };
+
+        if !force && mode == MouseMode::None {
+            return Response::Error {
+                message: format!(
+                    "session {name:?} has not enabled mouse reporting (DECSET 1000/1002/1006). \
+                     Use --force to send raw bytes anyway."
+                ),
+            };
+        }
+
+        // Resolve targets to coordinates.
+        let resolve = |target: &MouseTarget| -> Result<(u16, u16), String> {
+            match target {
+                MouseTarget::Coords { col, row } => {
+                    if *col >= cols || *row >= rows {
+                        return Err(format!(
+                            "coords ({col},{row}) out of bounds (terminal is {cols}x{rows})"
+                        ));
+                    }
+                    Ok((*col, *row))
+                }
+                MouseTarget::Text {
+                    needle,
+                    match_index,
+                } => {
+                    let hits = mouse::find_text(&screen_rows, needle);
+                    pick_match(&hits, *match_index, &format!("text {needle:?}"))
+                }
+                MouseTarget::Regex {
+                    pattern,
+                    match_index,
+                } => {
+                    let hits = match mouse::find_regex(&screen_rows, pattern) {
+                        Ok(h) => h,
+                        Err(e) => return Err(e.to_string()),
+                    };
+                    pick_match(&hits, *match_index, &format!("regex {pattern:?}"))
+                }
+            }
+        };
+
+        let events = match build_events(&action, &resolve, mode) {
+            Ok(evs) => evs,
+            Err(e) => return Response::Error { message: e },
+        };
+
+        let bytes = match mouse::encode(&events, encoding) {
+            Ok(b) => b,
+            Err(e) => {
+                return Response::Error {
+                    message: format!("encode mouse events: {e}"),
+                }
+            }
+        };
+
+        match session.write_bytes(&bytes) {
+            Ok(()) => Response::Ok,
+            Err(e) => Response::Error {
+                message: format!("Mouse write failed: {e}"),
+            },
+        }
+    }
+}
+
+fn vt_mode_to_proto(mode: vt100::MouseProtocolMode) -> MouseMode {
+    match mode {
+        vt100::MouseProtocolMode::None => MouseMode::None,
+        vt100::MouseProtocolMode::Press => MouseMode::Press,
+        vt100::MouseProtocolMode::PressRelease => MouseMode::PressRelease,
+        vt100::MouseProtocolMode::ButtonMotion => MouseMode::ButtonMotion,
+        vt100::MouseProtocolMode::AnyMotion => MouseMode::AnyMotion,
+    }
+}
+
+fn vt_encoding_to_proto(enc: vt100::MouseProtocolEncoding) -> MouseEncoding {
+    match enc {
+        vt100::MouseProtocolEncoding::Default => MouseEncoding::Default,
+        vt100::MouseProtocolEncoding::Utf8 => MouseEncoding::Utf8,
+        vt100::MouseProtocolEncoding::Sgr => MouseEncoding::Sgr,
+    }
+}
+
+fn pick_match(
+    hits: &[crate::mouse::ScreenMatch],
+    match_index: usize,
+    label: &str,
+) -> Result<(u16, u16), String> {
+    if hits.is_empty() {
+        return Err(format!("no match for {label} on visible screen"));
+    }
+    let chosen = hits.get(match_index).ok_or_else(|| {
+        format!(
+            "match-index {} out of range for {label} ({} match{})",
+            match_index,
+            hits.len(),
+            if hits.len() == 1 { "" } else { "es" }
+        )
+    })?;
+    Ok(chosen.center())
+}
+
+fn build_events<F>(
+    action: &MouseAction,
+    resolve: &F,
+    mode: MouseMode,
+) -> Result<Vec<WireEvent>, String>
+where
+    F: Fn(&MouseTarget) -> Result<(u16, u16), String>,
+{
+    use MouseAction::*;
+    let mut out = Vec::new();
+    match action {
+        Click {
+            target,
+            button,
+            mods,
+            clicks,
+        } => {
+            let (col, row) = resolve(target)?;
+            let n = (*clicks).max(1);
+            for _ in 0..n {
+                out.push(WireEvent::Down {
+                    col,
+                    row,
+                    button: *button,
+                    mods: *mods,
+                });
+                out.push(WireEvent::Up {
+                    col,
+                    row,
+                    button: *button,
+                    mods: *mods,
+                });
+            }
+        }
+        Down {
+            target,
+            button,
+            mods,
+        } => {
+            let (col, row) = resolve(target)?;
+            out.push(WireEvent::Down {
+                col,
+                row,
+                button: *button,
+                mods: *mods,
+            });
+        }
+        Up {
+            target,
+            button,
+            mods,
+        } => {
+            let (col, row) = resolve(target)?;
+            out.push(WireEvent::Up {
+                col,
+                row,
+                button: *button,
+                mods: *mods,
+            });
+        }
+        Move { target, mods } => {
+            if matches!(
+                mode,
+                MouseMode::None | MouseMode::Press | MouseMode::PressRelease
+            ) {
+                return Err(format!(
+                    "mouse mode {mode:?} does not report bare motion (need ButtonMotion or AnyMotion)"
+                ));
+            }
+            let (col, row) = resolve(target)?;
+            out.push(WireEvent::Move {
+                col,
+                row,
+                mods: *mods,
+            });
+        }
+        Drag {
+            from,
+            to,
+            button,
+            mods,
+        } => {
+            let (c1, r1) = resolve(from)?;
+            let (c2, r2) = resolve(to)?;
+            out.push(WireEvent::Down {
+                col: c1,
+                row: r1,
+                button: *button,
+                mods: *mods,
+            });
+            // Linearly interpolate intermediate cells so apps that track the path
+            // (selection drags, panel dividers) see motion, not a teleport.
+            for (col, row) in interpolate_path(c1, r1, c2, r2) {
+                out.push(WireEvent::DragMove {
+                    col,
+                    row,
+                    button: *button,
+                    mods: *mods,
+                });
+            }
+            out.push(WireEvent::Up {
+                col: c2,
+                row: r2,
+                button: *button,
+                mods: *mods,
+            });
+        }
+        Scroll {
+            target,
+            dir,
+            amount,
+            mods,
+        } => {
+            let (col, row) = match target {
+                Some(t) => resolve(t)?,
+                None => (0, 0),
+            };
+            let n = (*amount).max(1);
+            for _ in 0..n {
+                out.push(WireEvent::Scroll {
+                    col,
+                    row,
+                    dir: *dir,
+                    mods: *mods,
+                });
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Cells between (c1,r1) and (c2,r2) exclusive of both endpoints, using
+/// Bresenham-style stepping so straight horizontal/vertical drags emit one
+/// event per cell and diagonals stay roughly on the line.
+fn interpolate_path(c1: u16, r1: u16, c2: u16, r2: u16) -> Vec<(u16, u16)> {
+    let dx = (c2 as i32 - c1 as i32).abs();
+    let dy = (r2 as i32 - r1 as i32).abs();
+    let steps = dx.max(dy);
+    if steps <= 1 {
+        return Vec::new();
+    }
+    let mut out = Vec::with_capacity((steps - 1) as usize);
+    for i in 1..steps {
+        let t = i as f64 / steps as f64;
+        let col = (c1 as f64 + (c2 as f64 - c1 as f64) * t).round() as u16;
+        let row = (r1 as f64 + (r2 as f64 - r1 as f64) * t).round() as u16;
+        out.push((col, row));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::daemon::protocol::{MouseButton, ScrollDir};
+
+    fn coords(col: u16, row: u16) -> MouseTarget {
+        MouseTarget::Coords { col, row }
+    }
+
+    #[test]
+    fn build_click_emits_down_up() {
+        let action = MouseAction::Click {
+            target: coords(5, 5),
+            button: MouseButton::Left,
+            mods: Default::default(),
+            clicks: 1,
+        };
+        let resolve = |t: &MouseTarget| match t {
+            MouseTarget::Coords { col, row } => Ok((*col, *row)),
+            _ => Err("nope".into()),
+        };
+        let evs = build_events(&action, &resolve, MouseMode::PressRelease).unwrap();
+        assert_eq!(evs.len(), 2);
+        assert!(matches!(evs[0], WireEvent::Down { .. }));
+        assert!(matches!(evs[1], WireEvent::Up { .. }));
+    }
+
+    #[test]
+    fn build_double_click_clicks_2_emits_4_events() {
+        let action = MouseAction::Click {
+            target: coords(0, 0),
+            button: MouseButton::Left,
+            mods: Default::default(),
+            clicks: 2,
+        };
+        let resolve = |t: &MouseTarget| match t {
+            MouseTarget::Coords { col, row } => Ok((*col, *row)),
+            _ => Err("nope".into()),
+        };
+        let evs = build_events(&action, &resolve, MouseMode::PressRelease).unwrap();
+        assert_eq!(evs.len(), 4);
+    }
+
+    #[test]
+    fn build_drag_emits_down_path_up() {
+        let action = MouseAction::Drag {
+            from: coords(0, 0),
+            to: coords(5, 0),
+            button: MouseButton::Left,
+            mods: Default::default(),
+        };
+        let resolve = |t: &MouseTarget| match t {
+            MouseTarget::Coords { col, row } => Ok((*col, *row)),
+            _ => Err("nope".into()),
+        };
+        let evs = build_events(&action, &resolve, MouseMode::ButtonMotion).unwrap();
+        // Down + 4 intermediate (cols 1..=4) + Up
+        assert_eq!(evs.len(), 6);
+        assert!(matches!(evs[0], WireEvent::Down { col: 0, row: 0, .. }));
+        assert!(matches!(evs[5], WireEvent::Up { col: 5, row: 0, .. }));
+        for ev in &evs[1..5] {
+            assert!(matches!(ev, WireEvent::DragMove { .. }));
+        }
+    }
+
+    #[test]
+    fn build_move_rejected_when_mode_lacks_motion() {
+        let action = MouseAction::Move {
+            target: coords(0, 0),
+            mods: Default::default(),
+        };
+        let resolve = |_: &MouseTarget| Ok((0, 0));
+        let err = build_events(&action, &resolve, MouseMode::PressRelease).unwrap_err();
+        assert!(err.contains("does not report bare motion"));
+    }
+
+    #[test]
+    fn build_scroll_amount_replicates() {
+        let action = MouseAction::Scroll {
+            target: None,
+            dir: ScrollDir::Down,
+            amount: 5,
+            mods: Default::default(),
+        };
+        let resolve = |_: &MouseTarget| Ok((0, 0));
+        let evs = build_events(&action, &resolve, MouseMode::PressRelease).unwrap();
+        assert_eq!(evs.len(), 5);
+    }
+
+    #[test]
+    fn interpolate_horizontal() {
+        let path = interpolate_path(0, 0, 5, 0);
+        assert_eq!(path, vec![(1, 0), (2, 0), (3, 0), (4, 0)]);
+    }
+
+    #[test]
+    fn interpolate_short_emits_nothing() {
+        assert!(interpolate_path(0, 0, 1, 0).is_empty());
+        assert!(interpolate_path(0, 0, 0, 0).is_empty());
+    }
+
+    #[test]
+    fn pick_match_disambiguation() {
+        let hits = vec![
+            crate::mouse::ScreenMatch {
+                row: 0,
+                col_start: 0,
+                col_end: 3,
+            },
+            crate::mouse::ScreenMatch {
+                row: 1,
+                col_start: 4,
+                col_end: 6,
+            },
+        ];
+        assert_eq!(pick_match(&hits, 0, "x").unwrap(), (1, 0));
+        assert_eq!(pick_match(&hits, 1, "x").unwrap(), (5, 1));
+        assert!(pick_match(&hits, 5, "x").is_err());
+        assert!(pick_match(&[], 0, "x").is_err());
     }
 }

--- a/src/daemon/manager.rs
+++ b/src/daemon/manager.rs
@@ -246,6 +246,8 @@ impl SessionManager {
                     content_b64,
                     rows: session.size.rows,
                     cols: session.size.cols,
+                    mouse_cursor: session.mouse.cursor,
+                    mouse_held: !session.mouse.buttons_held.is_empty(),
                 }
             }
             None => Response::Error {
@@ -263,6 +265,8 @@ impl SessionManager {
                     rows_ansi,
                     rows: session.size.rows,
                     cols: session.size.cols,
+                    mouse_cursor: session.mouse.cursor,
+                    mouse_held: !session.mouse.buttons_held.is_empty(),
                 }
             }
             None => Response::Error {

--- a/src/daemon/manager.rs
+++ b/src/daemon/manager.rs
@@ -407,7 +407,7 @@ impl SessionManager {
                     if ch.is_empty() {
                         line.push(' ');
                     } else {
-                        line.push_str(&ch);
+                        line.push_str(ch);
                     }
                 }
                 text_rows.push(line);

--- a/src/daemon/manager.rs
+++ b/src/daemon/manager.rs
@@ -265,6 +265,8 @@ impl SessionManager {
                     rows_ansi,
                     rows: session.size.rows,
                     cols: session.size.cols,
+                    mouse_cursor: session.mouse.cursor,
+                    mouse_held: !session.mouse.buttons_held.is_empty(),
                 }
             }
             None => Response::Error {

--- a/src/daemon/manager.rs
+++ b/src/daemon/manager.rs
@@ -227,6 +227,8 @@ impl SessionManager {
                     rows: session.size.rows,
                     cols: session.size.cols,
                     cursor,
+                    mouse_cursor: session.mouse.cursor,
+                    mouse_held: !session.mouse.buttons_held.is_empty(),
                 }
             }
             None => Response::Error {

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -72,6 +72,14 @@ pub enum Request {
         name: String,
         size: TermSize,
     },
+    Mouse {
+        name: String,
+        action: MouseAction,
+        force: bool,
+    },
+    MouseState {
+        name: String,
+    },
     Wait {
         name: String,
         stable_ms: Option<u64>,
@@ -79,6 +87,102 @@ pub enum Request {
         timeout_ms: u64,
     },
     Shutdown,
+}
+
+/// Mouse button to send.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum MouseButton {
+    Left,
+    Right,
+    Middle,
+}
+
+/// Modifier keys held during a mouse event.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MouseMods {
+    pub shift: bool,
+    pub alt: bool,
+    pub ctrl: bool,
+}
+
+/// Scroll direction for the wheel.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ScrollDir {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+/// How to locate the cell to click.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind")]
+pub enum MouseTarget {
+    /// Absolute cell coordinates (0-based).
+    Coords { col: u16, row: u16 },
+    /// Find first (or nth) literal-text match on the visible screen.
+    Text { needle: String, match_index: usize },
+    /// Find first (or nth) regex match on the visible screen.
+    Regex { pattern: String, match_index: usize },
+}
+
+/// One mouse operation. Compound ops (click, drag) are expanded inside the daemon.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum MouseAction {
+    Click {
+        target: MouseTarget,
+        button: MouseButton,
+        mods: MouseMods,
+        clicks: u32,
+    },
+    Down {
+        target: MouseTarget,
+        button: MouseButton,
+        mods: MouseMods,
+    },
+    Up {
+        target: MouseTarget,
+        button: MouseButton,
+        mods: MouseMods,
+    },
+    Move {
+        target: MouseTarget,
+        mods: MouseMods,
+    },
+    Drag {
+        from: MouseTarget,
+        to: MouseTarget,
+        button: MouseButton,
+        mods: MouseMods,
+    },
+    Scroll {
+        target: Option<MouseTarget>,
+        dir: ScrollDir,
+        amount: u32,
+        mods: MouseMods,
+    },
+}
+
+/// Mouse-mode introspection: what the inner app has DECSET'd.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum MouseMode {
+    None,
+    Press,
+    PressRelease,
+    ButtonMotion,
+    AnyMotion,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum MouseEncoding {
+    Default,
+    Utf8,
+    Sgr,
 }
 
 /// A session's status info.
@@ -142,6 +246,10 @@ pub enum Response {
     },
     Scrollback {
         content: String,
+    },
+    MouseState {
+        mode: MouseMode,
+        encoding: MouseEncoding,
     },
     Error {
         message: String,

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -237,12 +237,23 @@ pub enum Response {
         content_b64: String,
         rows: u16,
         cols: u16,
+        /// Synthetic mouse cursor position (None until first mouse event, or after
+        /// resize-out-of-bounds clear). Renderers can paint an overlay at this cell.
+        mouse_cursor: Option<CursorPos>,
+        /// True when at least one mouse button is currently held (Down without
+        /// matching Up). Renderers use this to switch the cursor between an outline
+        /// (idle) and a filled block (drag/press in progress).
+        mouse_held: bool,
     },
     ScreenshotCells {
         /// Each row is a vector of ANSI-rendered strings (one per row, already SGR-formatted).
         rows_ansi: Vec<String>,
         rows: u16,
         cols: u16,
+        /// Synthetic mouse cursor position (see ScreenshotAnsi).
+        mouse_cursor: Option<CursorPos>,
+        /// Whether any mouse button is currently held.
+        mouse_held: bool,
     },
     Scrollback {
         content: String,

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -250,10 +250,6 @@ pub enum Response {
         rows_ansi: Vec<String>,
         rows: u16,
         cols: u16,
-        /// Synthetic mouse cursor position (see ScreenshotAnsi).
-        mouse_cursor: Option<CursorPos>,
-        /// Whether any mouse button is currently held.
-        mouse_held: bool,
     },
     Scrollback {
         content: String,

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -196,7 +196,7 @@ pub struct SessionInfo {
 }
 
 /// Cursor position.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CursorPos {
     pub row: u16,
     pub col: u16,
@@ -250,8 +250,38 @@ pub enum Response {
     MouseState {
         mode: MouseMode,
         encoding: MouseEncoding,
+        size: TermSize,
+        cursor: Option<CursorPos>,
+        buttons_held: Vec<MouseButton>,
+        last_event: Option<MouseLastEvent>,
     },
     Error {
         message: String,
     },
+}
+
+/// Kind of the most recent mouse event tu emitted (for `mouse state`).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum MouseEventKind {
+    Down,
+    Up,
+    Move,
+    DragMove,
+    Scroll,
+}
+
+/// Snapshot of the last mouse event written to the PTY for this session.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MouseLastEvent {
+    pub kind: MouseEventKind,
+    pub col: u16,
+    pub row: u16,
+    /// Some for Down/Up/DragMove; None for Move (no button) and Scroll
+    /// (direction is in `scroll_dir` instead).
+    pub button: Option<MouseButton>,
+    pub scroll_dir: Option<ScrollDir>,
+    pub mods: MouseMods,
+    /// Unix-epoch seconds when tu emitted the event.
+    pub ts_unix: u64,
 }

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -250,6 +250,12 @@ pub enum Response {
         rows_ansi: Vec<String>,
         rows: u16,
         cols: u16,
+        /// Synthetic mouse cursor position (None until first event; cleared on
+        /// resize-out-of-bounds). Monitor paints a △ overlay at this cell.
+        mouse_cursor: Option<CursorPos>,
+        /// True when at least one mouse button is currently held; switches the
+        /// cursor glyph from outline to filled.
+        mouse_held: bool,
     },
     Scrollback {
         content: String,

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -223,6 +223,13 @@ pub enum Response {
         rows: u16,
         cols: u16,
         cursor: CursorPos,
+        /// Synthetic mouse cursor position (None until first mouse event;
+        /// cleared on resize-out-of-bounds). Reported as metadata only —
+        /// never spliced into `content` so regex / grep over the body stays
+        /// faithful to what the inner app drew.
+        mouse_cursor: Option<CursorPos>,
+        /// True when at least one mouse button is currently held.
+        mouse_held: bool,
     },
     Cursor {
         #[serde(flatten)]

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -171,7 +171,6 @@ pub enum MouseAction {
 #[serde(rename_all = "lowercase")]
 pub enum MouseMode {
     None,
-    Press,
     PressRelease,
     ButtonMotion,
     AnyMotion,

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -293,28 +293,21 @@ async fn handle_wait(
     }
 }
 
-/// Read the screen contents as plain text from a parser, mirroring Session::screenshot_text().
+/// Read the screen contents as plain text from a parser, mirroring
+/// `Session::screenshot_text()` — uses the shared `Screen::text_rows`
+/// builder so wait, screenshots, and mouse target resolution all see the
+/// exact same view of the screen.
 async fn screenshot_text_from_parser(
     parser: &Mutex<crate::emu::Parser>,
-    size: &crate::daemon::protocol::TermSize,
+    _size: &crate::daemon::protocol::TermSize,
 ) -> String {
     let parser = parser.lock().await;
-    let screen = parser.screen();
-    let mut lines = Vec::with_capacity(size.rows as usize);
-    for row in 0..size.rows {
-        let mut line = String::new();
-        for col in 0..size.cols {
-            let cell = screen.cell(row, col).unwrap();
-            let ch = cell.contents();
-            if ch.is_empty() {
-                line.push(' ');
-            } else {
-                line.push_str(ch);
-            }
-        }
-        let trimmed = line.trim_end();
-        lines.push(trimmed.to_string());
-    }
+    let mut lines: Vec<String> = parser
+        .screen()
+        .text_rows()
+        .into_iter()
+        .map(|l| l.trim_end().to_string())
+        .collect();
     while lines.last().is_some_and(|l| l.is_empty()) {
         lines.pop();
     }

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -302,7 +302,7 @@ async fn screenshot_text_from_parser(
             if ch.is_empty() {
                 line.push(' ');
             } else {
-                line.push_str(&ch);
+                line.push_str(ch);
             }
         }
         let trimmed = line.trim_end();

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -180,19 +180,26 @@ async fn handle_connection(stream: tokio::net::UnixStream, manager: &Mutex<Sessi
 
     let is_shutdown = matches!(request, Request::Shutdown);
 
-    // Handle Wait outside the manager lock to avoid blocking other requests
-    // during the polling loop.
-    let response = if let Request::Wait {
-        name,
-        stable_ms,
-        text_pattern,
-        timeout_ms,
-    } = request
-    {
-        handle_wait(manager, &name, stable_ms, text_pattern, timeout_ms).await
-    } else {
-        let mut mgr = manager.lock().await;
-        mgr.handle(request).await
+    // Wait and Mouse run outside the manager lock so they don't block other
+    // requests. Wait polls for up to a few seconds; Mouse paces interpolated
+    // motion events with sleeps so the synthetic cursor visibly glides in
+    // `tu monitor` and the inner app sees real motion rather than a teleport.
+    let response = match request {
+        Request::Wait {
+            name,
+            stable_ms,
+            text_pattern,
+            timeout_ms,
+        } => handle_wait(manager, &name, stable_ms, text_pattern, timeout_ms).await,
+        Request::Mouse {
+            name,
+            action,
+            force,
+        } => crate::daemon::manager::handle_mouse_glided(manager, name, action, force).await,
+        other => {
+            let mut mgr = manager.lock().await;
+            mgr.handle(other).await
+        }
     };
 
     let mut json = serde_json::to_string(&response).unwrap();

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -288,7 +288,7 @@ async fn handle_wait(
 
 /// Read the screen contents as plain text from a parser, mirroring Session::screenshot_text().
 async fn screenshot_text_from_parser(
-    parser: &Mutex<vt100::Parser>,
+    parser: &Mutex<crate::emu::Parser>,
     size: &crate::daemon::protocol::TermSize,
 ) -> String {
     let parser = parser.lock().await;

--- a/src/daemon/session.rs
+++ b/src/daemon/session.rs
@@ -8,8 +8,47 @@ use nix::unistd::Pid;
 use tokio::io::AsyncReadExt;
 use tokio::sync::Mutex;
 
-use crate::daemon::protocol::{CursorPos, SessionInfo, TermSize};
+use crate::daemon::protocol::{CursorPos, MouseButton, MouseLastEvent, SessionInfo, TermSize};
 use crate::pty;
+
+/// Tu's idea of the synthetic mouse state for a session: where the cursor was
+/// left after the most recent emitted event, which buttons are still held
+/// (down without a matching up), and a snapshot of the most recent event.
+///
+/// The inner application is under no obligation to render the mouse cursor,
+/// so this is the only authoritative source for "where am I and what's held"
+/// when an agent loses track between calls.
+#[derive(Debug, Default)]
+pub struct MouseTracker {
+    pub cursor: Option<CursorPos>,
+    pub buttons_held: Vec<MouseButton>,
+    pub last_event: Option<MouseLastEvent>,
+}
+
+impl MouseTracker {
+    pub fn record_position(&mut self, col: u16, row: u16) {
+        self.cursor = Some(CursorPos { row, col });
+    }
+
+    pub fn press(&mut self, button: MouseButton) {
+        if !self.buttons_held.contains(&button) {
+            self.buttons_held.push(button);
+        }
+    }
+
+    pub fn release(&mut self, button: MouseButton) {
+        self.buttons_held.retain(|b| *b != button);
+    }
+
+    /// Clear the cursor if it is now outside the new size.
+    pub fn clamp_to_size(&mut self, size: &TermSize) {
+        if let Some(pos) = self.cursor {
+            if pos.col >= size.cols || pos.row >= size.rows {
+                self.cursor = None;
+            }
+        }
+    }
+}
 
 /// A terminal session: a child process in a PTY with a vt100 screen buffer.
 pub struct Session {
@@ -20,6 +59,7 @@ pub struct Session {
     pub size: TermSize,
     pub alive: bool,
     pub exit_code: Option<i32>,
+    pub mouse: MouseTracker,
 }
 
 impl Session {
@@ -47,6 +87,7 @@ impl Session {
             size,
             alive: true,
             exit_code: None,
+            mouse: MouseTracker::default(),
         })
     }
 
@@ -274,7 +315,8 @@ impl Session {
         pty::resize::resize_pty(&self.master_fd, &size)?;
         let mut parser = self.parser.lock().await;
         parser.set_size(size.rows, size.cols);
-        self.size = size;
+        self.size = size.clone();
+        self.mouse.clamp_to_size(&size);
         Ok(())
     }
 

--- a/src/daemon/session.rs
+++ b/src/daemon/session.rs
@@ -163,7 +163,7 @@ impl Session {
                 if ch.is_empty() {
                     line.push(' ');
                 } else {
-                    line.push_str(&ch);
+                    push_sanitized(&mut line, &ch);
                 }
             }
             let trimmed = line.trim_end();
@@ -246,7 +246,7 @@ impl Session {
                 if ch.is_empty() {
                     line.push(' ');
                 } else {
-                    line.push_str(&ch);
+                    push_sanitized(&mut line, &ch);
                 }
             }
 
@@ -339,6 +339,22 @@ impl Session {
 impl Drop for Session {
     fn drop(&mut self) {
         self.kill();
+    }
+}
+
+/// Append a cell's text content to `out`, replacing any control byte (< 0x20,
+/// excluding tab) with a space. A misbehaving inner app — or a sequence the
+/// vt100 parser doesn't recognise — can leave a stray ESC (0x1B) inside a
+/// cell; if we forwarded that raw it would re-enter the user's terminal as
+/// the start of an escape sequence and render as caret-notation (`^[`),
+/// corrupting the row.
+fn push_sanitized(out: &mut String, content: &str) {
+    for c in content.chars() {
+        if (c as u32) < 0x20 && c != '\t' {
+            out.push(' ');
+        } else {
+            out.push(c);
+        }
     }
 }
 

--- a/src/daemon/session.rs
+++ b/src/daemon/session.rs
@@ -163,7 +163,7 @@ impl Session {
                 if ch.is_empty() {
                     line.push(' ');
                 } else {
-                    push_sanitized(&mut line, &ch);
+                    push_sanitized(&mut line, ch);
                 }
             }
             let trimmed = line.trim_end();
@@ -246,7 +246,7 @@ impl Session {
                 if ch.is_empty() {
                     line.push(' ');
                 } else {
-                    push_sanitized(&mut line, &ch);
+                    push_sanitized(&mut line, ch);
                 }
             }
 
@@ -314,7 +314,7 @@ impl Session {
     pub async fn resize(&mut self, size: TermSize) -> Result<()> {
         pty::resize::resize_pty(&self.master_fd, &size)?;
         let mut parser = self.parser.lock().await;
-        parser.set_size(size.rows, size.cols);
+        parser.screen_mut().set_size(size.rows, size.cols);
         self.size = size.clone();
         self.mouse.clamp_to_size(&size);
         Ok(())

--- a/src/daemon/session.rs
+++ b/src/daemon/session.rs
@@ -168,22 +168,16 @@ impl Session {
     /// Get the current screen contents as plain text.
     pub async fn screenshot_text(&self) -> String {
         let parser = self.parser.lock().await;
-        let screen = parser.screen();
-        let mut lines = Vec::with_capacity(self.size.rows as usize);
-        for row in 0..self.size.rows {
-            let mut line = String::new();
-            for col in 0..self.size.cols {
-                let cell = screen.cell(row, col).unwrap();
-                let ch = cell.contents();
-                if ch.is_empty() {
-                    line.push(' ');
-                } else {
-                    push_sanitized(&mut line, ch);
-                }
-            }
-            let trimmed = line.trim_end();
-            lines.push(trimmed.to_string());
-        }
+        let mut lines: Vec<String> = parser
+            .screen()
+            .text_rows()
+            .into_iter()
+            .map(|line| {
+                let mut sanitized = String::with_capacity(line.len());
+                push_sanitized(&mut sanitized, &line);
+                sanitized.trim_end().to_string()
+            })
+            .collect();
         while lines.last().is_some_and(|l| l.is_empty()) {
             lines.pop();
         }

--- a/src/daemon/session.rs
+++ b/src/daemon/session.rs
@@ -55,7 +55,7 @@ pub struct Session {
     pub name: String,
     pub master_fd: OwnedFd,
     pub pid: Pid,
-    pub parser: Arc<Mutex<vt100::Parser>>,
+    pub parser: Arc<Mutex<crate::emu::Parser>>,
     pub size: TermSize,
     pub alive: bool,
     pub exit_code: Option<i32>,
@@ -77,7 +77,7 @@ impl Session {
         shell: bool,
     ) -> Result<Self> {
         let pty_proc = pty::spawn::spawn(command, args, &size, env, cwd, term, shell)?;
-        let parser = vt100::Parser::new(size.rows, size.cols, scrollback);
+        let parser = crate::emu::Parser::new(size.rows, size.cols, scrollback);
 
         Ok(Self {
             name,
@@ -95,14 +95,18 @@ impl Session {
     pub fn start_reader(&self) -> Result<()> {
         let parser = self.parser.clone();
 
-        // Duplicate the fd so the async reader owns it independently
-        let dup_fd = nix::unistd::dup(&self.master_fd).context("dup master_fd")?;
+        // Two dup'd fds: one for the async reader, one for the writeback path
+        // (parser-driven replies to terminal queries). They share the same
+        // underlying open description, so writes are atomic even though the
+        // tasks aren't synchronised at the fd level.
+        let read_fd = nix::unistd::dup(&self.master_fd).context("dup master_fd (read)")?;
+        let write_fd = nix::unistd::dup(&self.master_fd).context("dup master_fd (write)")?;
 
         tokio::spawn(async move {
             // Safety: we just dup'd the fd, so this is a valid owned fd.
-            let std_file = unsafe { std::fs::File::from_raw_fd(dup_fd.as_raw_fd()) };
+            let std_file = unsafe { std::fs::File::from_raw_fd(read_fd.as_raw_fd()) };
             // Prevent the OwnedFd from closing separately — std_file now owns the underlying fd
-            std::mem::forget(dup_fd);
+            std::mem::forget(read_fd);
 
             let mut async_file = tokio::io::BufReader::new(tokio::fs::File::from_std(std_file));
             let mut buf = [0u8; 4096];
@@ -111,8 +115,19 @@ impl Session {
                 match async_file.read(&mut buf).await {
                     Ok(0) => break,
                     Ok(n) => {
-                        let mut p = parser.lock().await;
-                        p.process(&buf[..n]);
+                        let pending = {
+                            let mut p = parser.lock().await;
+                            p.process(&buf[..n]);
+                            // The terminal may have queued replies (DA / cursor
+                            // position reports / DCS terminfo queries / etc.)
+                            // in response to queries from the inner app.
+                            // Forward them back to the PTY so curses apps
+                            // (vim, less, mc) don't hang waiting for them.
+                            p.take_pending_writes()
+                        };
+                        if !pending.is_empty() {
+                            let _ = crate::pty::input::write_to_pty(&write_fd, &pending);
+                        }
                     }
                     Err(e) => {
                         if e.raw_os_error() == Some(libc::EIO) {
@@ -192,8 +207,8 @@ impl Session {
 
         for row in 0..self.size.rows {
             let mut line = String::new();
-            let mut prev_fg = vt100::Color::Default;
-            let mut prev_bg = vt100::Color::Default;
+            let mut prev_fg = crate::emu::Color::Default;
+            let mut prev_bg = crate::emu::Color::Default;
             let mut prev_bold = false;
             let mut prev_inverse = false;
             let mut prev_underline = false;
@@ -358,10 +373,10 @@ fn push_sanitized(out: &mut String, content: &str) {
     }
 }
 
-fn push_fg_sgr(s: &mut String, color: vt100::Color) {
+fn push_fg_sgr(s: &mut String, color: crate::emu::Color) {
     match color {
-        vt100::Color::Default => {}
-        vt100::Color::Idx(i) => {
+        crate::emu::Color::Default => {}
+        crate::emu::Color::Idx(i) => {
             if i < 8 {
                 s.push_str(&format!(";{}", 30 + i));
             } else if i < 16 {
@@ -370,16 +385,16 @@ fn push_fg_sgr(s: &mut String, color: vt100::Color) {
                 s.push_str(&format!(";38;5;{}", i));
             }
         }
-        vt100::Color::Rgb(r, g, b) => {
+        crate::emu::Color::Rgb(r, g, b) => {
             s.push_str(&format!(";38;2;{};{};{}", r, g, b));
         }
     }
 }
 
-fn push_bg_sgr(s: &mut String, color: vt100::Color) {
+fn push_bg_sgr(s: &mut String, color: crate::emu::Color) {
     match color {
-        vt100::Color::Default => {}
-        vt100::Color::Idx(i) => {
+        crate::emu::Color::Default => {}
+        crate::emu::Color::Idx(i) => {
             if i < 8 {
                 s.push_str(&format!(";{}", 40 + i));
             } else if i < 16 {
@@ -388,7 +403,7 @@ fn push_bg_sgr(s: &mut String, color: vt100::Color) {
                 s.push_str(&format!(";48;5;{}", i));
             }
         }
-        vt100::Color::Rgb(r, g, b) => {
+        crate::emu::Color::Rgb(r, g, b) => {
             s.push_str(&format!(";48;2;{};{};{}", r, g, b));
         }
     }

--- a/src/emu.rs
+++ b/src/emu.rs
@@ -1,0 +1,606 @@
+//! Terminal-emulator wrapper around `alacritty_terminal` (and its embedded
+//! `vte::ansi` parser).
+//!
+//! Why this layer exists: tu started on the `vt100` crate, which doesn't
+//! consume modern shell-integration escapes (OSC 133 semantic prompts, APC,
+//! and friends) — they leak into cells and render as `^[…` artifacts. We
+//! switched to alacritty's emulator which handles those silently.
+//!
+//! The public surface here intentionally mirrors what we previously consumed
+//! from `vt100`:
+//!
+//! - `Parser::new(rows, cols, scrollback)`, `parser.process(&[u8])`,
+//!   `parser.screen()` / `screen_mut()`.
+//! - `Screen::cell(row, col)`, `cursor_position()`, `size()`, `set_size(...)`,
+//!   `contents()` / `contents_formatted()`, plus mouse-mode introspection.
+//! - `Cell::contents/fgcolor/bgcolor/bold/italic/underline/inverse/is_wide_continuation`.
+//! - `Color::{Default, Idx, Rgb}`.
+//!
+//! That kept the rest of the codebase mostly untouched. Where alacritty's
+//! data model differs (it has no "default" color sentinel — Named/Indexed/Spec
+//! collapse onto each other), we map back to a 3-variant `Color` to preserve
+//! the SGR-emission code in `daemon::session::screenshot_cells`.
+
+use std::ops::Range;
+use std::sync::{Arc, Mutex};
+
+use alacritty_terminal::event::{Event, EventListener};
+use alacritty_terminal::grid::Dimensions;
+use alacritty_terminal::index::{Column, Line, Point};
+use alacritty_terminal::term::cell::{Cell as AlacCell, Flags as AlacFlags};
+use alacritty_terminal::term::test::TermSize as AlacSize;
+use alacritty_terminal::term::{Config as AlacConfig, Term, TermMode};
+use alacritty_terminal::vte::ansi;
+
+/// Drop-in stand-in for `vt100::Color`. Identical semantics in the SGR codepath
+/// in `daemon::session.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Color {
+    Default,
+    Idx(u8),
+    Rgb(u8, u8, u8),
+}
+
+impl Color {
+    fn from_alac(c: ansi::Color) -> Self {
+        match c {
+            ansi::Color::Named(named) => match named {
+                // The "logical default" colors map back to Default so our
+                // SGR-emission omits a foreground/background code (matching
+                // vt100's behaviour and how a real terminal renders).
+                ansi::NamedColor::Foreground | ansi::NamedColor::Background => Color::Default,
+                other => Color::Idx(other as u8),
+            },
+            ansi::Color::Spec(rgb) => Color::Rgb(rgb.r, rgb.g, rgb.b),
+            ansi::Color::Indexed(i) => Color::Idx(i),
+        }
+    }
+}
+
+/// Mouse reporting mode the inner app has DECSET'd.
+///
+/// `Press` is exposed for protocol parity with the original `vt100`-based
+/// surface (and the `tu mouse state` JSON), but in practice alacritty does
+/// not separately track X10 press-only mode — anything that turns on click
+/// reporting is treated as press+release.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum MouseProtocolMode {
+    None,
+    Press,
+    PressRelease,
+    ButtonMotion,
+    AnyMotion,
+}
+
+/// Wire encoding for mouse reports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseProtocolEncoding {
+    Default,
+    Utf8,
+    Sgr,
+}
+
+/// One snapshot cell, owned and `Send`-safe, mirroring vt100's `Cell` API.
+#[derive(Debug, Clone)]
+pub struct Cell {
+    contents: String,
+    fg: Color,
+    bg: Color,
+    bold: bool,
+    italic: bool,
+    underline: bool,
+    inverse: bool,
+    is_wide_continuation: bool,
+}
+
+impl Cell {
+    pub fn contents(&self) -> &str {
+        &self.contents
+    }
+    pub fn fgcolor(&self) -> Color {
+        self.fg
+    }
+    pub fn bgcolor(&self) -> Color {
+        self.bg
+    }
+    pub fn bold(&self) -> bool {
+        self.bold
+    }
+    pub fn italic(&self) -> bool {
+        self.italic
+    }
+    pub fn underline(&self) -> bool {
+        self.underline
+    }
+    pub fn inverse(&self) -> bool {
+        self.inverse
+    }
+    pub fn is_wide_continuation(&self) -> bool {
+        self.is_wide_continuation
+    }
+}
+
+fn cell_from_alac(c: &AlacCell) -> Cell {
+    let flags = c.flags;
+    let inverse = flags.contains(AlacFlags::INVERSE);
+    let bold = flags.contains(AlacFlags::BOLD);
+    let italic = flags.contains(AlacFlags::ITALIC);
+    let underline = flags.intersects(
+        AlacFlags::UNDERLINE
+            | AlacFlags::DOUBLE_UNDERLINE
+            | AlacFlags::DOTTED_UNDERLINE
+            | AlacFlags::DASHED_UNDERLINE
+            | AlacFlags::UNDERCURL,
+    );
+    let is_wide_continuation = flags.contains(AlacFlags::WIDE_CHAR_SPACER);
+
+    // A cell whose `c` is `' '` and which has no zero-width characters reads
+    // as "empty" to the rest of tu (matches vt100's `cell.contents().is_empty()`
+    // behaviour). Encode that by emitting an empty string.
+    let mut contents = if c.c == ' ' && !flags.contains(AlacFlags::WIDE_CHAR) {
+        String::new()
+    } else {
+        let mut s = String::new();
+        s.push(c.c);
+        s
+    };
+    if let Some(zw) = c.zerowidth() {
+        for ch in zw {
+            contents.push(*ch);
+        }
+    }
+
+    Cell {
+        contents,
+        fg: Color::from_alac(c.fg),
+        bg: Color::from_alac(c.bg),
+        bold,
+        italic,
+        underline,
+        inverse,
+        is_wide_continuation,
+    }
+}
+
+/// EventListener proxy that captures `PtyWrite` events into a shared buffer.
+///
+/// Why this matters: alacritty's `Term` does not write to the PTY itself —
+/// when the inner application sends a query that needs a reply (Device
+/// Attributes, cursor-position report, etc.), alacritty produces an
+/// `Event::PtyWrite(reply)` and expects the listener to forward those bytes
+/// to the PTY master. Dropping them silently is what made mc, vim, and other
+/// curses apps freeze on startup waiting for terminal responses.
+///
+/// The buffer is `Arc<Mutex<…>>` so the proxy (which lives inside `Term` by
+/// value) and `Parser::take_pending_writes` can access it from the same task
+/// without ownership gymnastics. The mutex never sees contention because
+/// the parent `Session` already serialises every `process()` + drain pair
+/// behind its own tokio mutex.
+#[derive(Default, Clone)]
+struct CaptureProxy {
+    pending: Arc<Mutex<Vec<u8>>>,
+}
+
+impl EventListener for CaptureProxy {
+    fn send_event(&self, ev: Event) {
+        if let Event::PtyWrite(bytes) = ev {
+            if let Ok(mut buf) = self.pending.lock() {
+                buf.extend_from_slice(bytes.as_bytes());
+            }
+        }
+    }
+}
+
+/// Alacritty-backed terminal parser. Public surface mirrors the slice of
+/// `vt100::Parser` we used.
+pub struct Parser {
+    term: Term<CaptureProxy>,
+    processor: ansi::Processor,
+    rows: u16,
+    cols: u16,
+    pending_writes: Arc<Mutex<Vec<u8>>>,
+}
+
+impl Parser {
+    pub fn new(rows: u16, cols: u16, scrollback: usize) -> Self {
+        let size = AlacSize::new(cols as usize, rows as usize);
+        let config = AlacConfig {
+            scrolling_history: scrollback,
+            ..Default::default()
+        };
+        let pending_writes: Arc<Mutex<Vec<u8>>> = Arc::default();
+        let proxy = CaptureProxy {
+            pending: pending_writes.clone(),
+        };
+        let term = Term::new(config, &size, proxy);
+        Self {
+            term,
+            processor: ansi::Processor::new(),
+            rows,
+            cols,
+            pending_writes,
+        }
+    }
+
+    /// Feed PTY bytes through the vte parser into the alacritty terminal.
+    pub fn process(&mut self, bytes: &[u8]) {
+        self.processor.advance(&mut self.term, bytes);
+    }
+
+    /// Drain any bytes the terminal wants to write back to the PTY (replies
+    /// to Device Attributes queries, cursor reports, etc.). Caller is
+    /// responsible for actually writing these to the master fd.
+    pub fn take_pending_writes(&mut self) -> Vec<u8> {
+        match self.pending_writes.lock() {
+            Ok(mut buf) => std::mem::take(&mut *buf),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    pub fn screen(&self) -> Screen<'_> {
+        Screen { parser: self }
+    }
+
+    pub fn screen_mut(&mut self) -> ScreenMut<'_> {
+        ScreenMut { parser: self }
+    }
+}
+
+/// Read-only view into the parser's terminal state.
+pub struct Screen<'a> {
+    parser: &'a Parser,
+}
+
+impl<'a> Screen<'a> {
+    pub fn cell(&self, row: u16, col: u16) -> Option<Cell> {
+        if row >= self.parser.rows || col >= self.parser.cols {
+            return None;
+        }
+        let grid = self.parser.term.grid();
+        let cell = &grid[Line(row as i32)][Column(col as usize)];
+        Some(cell_from_alac(cell))
+    }
+
+    /// Visible-screen cursor position as `(row, col)`, both 0-based.
+    /// Wraps the alacritty cursor to row 0 if it sits off-screen (this
+    /// matches what vt100 returned and what `tu cursor` documents).
+    pub fn cursor_position(&self) -> (u16, u16) {
+        let p: Point = self.parser.term.grid().cursor.point;
+        let row = p.line.0.max(0).min((self.parser.rows as i32) - 1) as u16;
+        let col = p.column.0.min(self.parser.cols.saturating_sub(1) as usize) as u16;
+        (row, col)
+    }
+
+    pub fn size(&self) -> (u16, u16) {
+        (self.parser.rows, self.parser.cols)
+    }
+
+    /// Plain-text dump of visible screen + scrollback, line by line.
+    pub fn contents(&self) -> String {
+        let grid = self.parser.term.grid();
+        let total = grid.total_lines() as i32;
+        let screen_lines = grid.screen_lines() as i32;
+        // History extends from -(history_size) to -1; visible from 0 to
+        // screen_lines-1.
+        let history_size = (total - screen_lines).max(0);
+        let range: Range<i32> = -history_size..screen_lines;
+        let mut out = String::new();
+        for line in range {
+            let mut buf = String::new();
+            for col in 0..self.parser.cols as usize {
+                let cell = &grid[Line(line)][Column(col)];
+                if cell.flags.contains(AlacFlags::WIDE_CHAR_SPACER) {
+                    continue;
+                }
+                if cell.c == ' ' {
+                    buf.push(' ');
+                } else {
+                    buf.push(cell.c);
+                    if let Some(zw) = cell.zerowidth() {
+                        for ch in zw {
+                            buf.push(*ch);
+                        }
+                    }
+                }
+            }
+            // Trim trailing spaces; the consumer can re-pad if it cares.
+            while buf.ends_with(' ') {
+                buf.pop();
+            }
+            out.push_str(&buf);
+            out.push('\n');
+        }
+        // Drop trailing newline if present so callers that join lines
+        // don't get a double-newline at the end.
+        if out.ends_with('\n') {
+            out.pop();
+        }
+        out
+    }
+
+    /// Re-emit the visible screen as raw ANSI bytes — used by the PNG path
+    /// to feed a fresh emulator on the client side.
+    pub fn contents_formatted(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(self.parser.rows as usize * self.parser.cols as usize);
+        // Reset and place cursor at home.
+        out.extend_from_slice(b"\x1b[2J\x1b[H");
+        let mut prev_fg = Color::Default;
+        let mut prev_bg = Color::Default;
+        let mut prev_bold = false;
+        let mut prev_italic = false;
+        let mut prev_underline = false;
+        let mut prev_inverse = false;
+        for row in 0..self.parser.rows {
+            for col in 0..self.parser.cols {
+                let Some(cell) = self.cell(row, col) else {
+                    continue;
+                };
+                if cell.is_wide_continuation {
+                    continue;
+                }
+                let fg = cell.fg;
+                let bg = cell.bg;
+                let bold = cell.bold;
+                let italic = cell.italic;
+                let underline = cell.underline;
+                let inverse = cell.inverse;
+                let attrs_changed = fg != prev_fg
+                    || bg != prev_bg
+                    || bold != prev_bold
+                    || italic != prev_italic
+                    || underline != prev_underline
+                    || inverse != prev_inverse;
+                if attrs_changed {
+                    out.extend_from_slice(b"\x1b[0");
+                    if bold {
+                        out.extend_from_slice(b";1");
+                    }
+                    if italic {
+                        out.extend_from_slice(b";3");
+                    }
+                    if underline {
+                        out.extend_from_slice(b";4");
+                    }
+                    if inverse {
+                        out.extend_from_slice(b";7");
+                    }
+                    push_fg_sgr(&mut out, fg);
+                    push_bg_sgr(&mut out, bg);
+                    out.push(b'm');
+                    prev_fg = fg;
+                    prev_bg = bg;
+                    prev_bold = bold;
+                    prev_italic = italic;
+                    prev_underline = underline;
+                    prev_inverse = inverse;
+                }
+                let s = cell.contents();
+                if s.is_empty() {
+                    out.push(b' ');
+                } else {
+                    out.extend_from_slice(s.as_bytes());
+                }
+            }
+            if row + 1 < self.parser.rows {
+                out.extend_from_slice(b"\r\n");
+            }
+        }
+        out.extend_from_slice(b"\x1b[0m");
+        out
+    }
+
+    pub fn mouse_protocol_mode(&self) -> MouseProtocolMode {
+        let mode = self.parser.term.mode();
+        // Inspect in order of strongest report set (AnyMotion implies the rest).
+        if mode.contains(TermMode::MOUSE_MOTION) {
+            MouseProtocolMode::AnyMotion
+        } else if mode.contains(TermMode::MOUSE_DRAG) {
+            MouseProtocolMode::ButtonMotion
+        } else if mode.contains(TermMode::MOUSE_REPORT_CLICK) {
+            // Alacritty doesn't separately track "report on press only"
+            // (DECSET 9, the original X10 protocol) versus "press + release"
+            // (DECSET 1000). Anything that enables MOUSE_REPORT_CLICK in
+            // alacritty is press+release in practice — that's what every
+            // modern app uses.
+            MouseProtocolMode::PressRelease
+        } else {
+            MouseProtocolMode::None
+        }
+    }
+
+    pub fn mouse_protocol_encoding(&self) -> MouseProtocolEncoding {
+        let mode = self.parser.term.mode();
+        if mode.contains(TermMode::SGR_MOUSE) {
+            MouseProtocolEncoding::Sgr
+        } else if mode.contains(TermMode::UTF8_MOUSE) {
+            MouseProtocolEncoding::Utf8
+        } else {
+            MouseProtocolEncoding::Default
+        }
+    }
+}
+
+pub struct ScreenMut<'a> {
+    parser: &'a mut Parser,
+}
+
+impl<'a> ScreenMut<'a> {
+    pub fn set_size(&mut self, rows: u16, cols: u16) {
+        let size = AlacSize::new(cols as usize, rows as usize);
+        self.parser.term.resize(size);
+        self.parser.rows = rows;
+        self.parser.cols = cols;
+    }
+}
+
+fn push_fg_sgr(out: &mut Vec<u8>, color: Color) {
+    match color {
+        Color::Default => {}
+        Color::Idx(i) => {
+            if i < 8 {
+                out.extend_from_slice(format!(";{}", 30 + i).as_bytes());
+            } else if i < 16 {
+                out.extend_from_slice(format!(";{}", 90 + i - 8).as_bytes());
+            } else {
+                out.extend_from_slice(format!(";38;5;{i}").as_bytes());
+            }
+        }
+        Color::Rgb(r, g, b) => {
+            out.extend_from_slice(format!(";38;2;{r};{g};{b}").as_bytes());
+        }
+    }
+}
+
+fn push_bg_sgr(out: &mut Vec<u8>, color: Color) {
+    match color {
+        Color::Default => {}
+        Color::Idx(i) => {
+            if i < 8 {
+                out.extend_from_slice(format!(";{}", 40 + i).as_bytes());
+            } else if i < 16 {
+                out.extend_from_slice(format!(";{}", 100 + i - 8).as_bytes());
+            } else {
+                out.extend_from_slice(format!(";48;5;{i}").as_bytes());
+            }
+        }
+        Color::Rgb(r, g, b) => {
+            out.extend_from_slice(format!(";48;2;{r};{g};{b}").as_bytes());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parser_reads_ascii() {
+        let mut p = Parser::new(2, 10, 0);
+        p.process(b"hi");
+        let s = p.screen();
+        let c = s.cell(0, 0).unwrap();
+        assert_eq!(c.contents(), "h");
+        let c = s.cell(0, 1).unwrap();
+        assert_eq!(c.contents(), "i");
+    }
+
+    #[test]
+    fn sgr_red_foreground_round_trip() {
+        let mut p = Parser::new(2, 10, 0);
+        p.process(b"\x1b[31mA");
+        let c = p.screen().cell(0, 0).unwrap();
+        assert!(matches!(c.fgcolor(), Color::Idx(1)));
+        assert_eq!(c.contents(), "A");
+    }
+
+    #[test]
+    fn osc_133_silently_consumed_no_caret_artifact() {
+        // OSC 133;A (semantic prompt mark, terminated by ST = ESC \).
+        // Followed by visible text. The ESC should NOT end up in any cell.
+        let mut p = Parser::new(2, 10, 0);
+        p.process(b"\x1b]133;A\x1b\\hello");
+        let mut buf = String::new();
+        for col in 0..10 {
+            let cell = p.screen().cell(0, col).unwrap();
+            if cell.contents().is_empty() {
+                buf.push(' ');
+            } else {
+                buf.push_str(cell.contents());
+            }
+        }
+        assert!(
+            !buf.contains('\u{1b}'),
+            "row contained an unparsed ESC byte: {buf:?}"
+        );
+        assert!(
+            buf.starts_with("hello"),
+            "expected hello prefix, got {buf:?}"
+        );
+    }
+
+    #[test]
+    fn apc_silently_consumed() {
+        let mut p = Parser::new(2, 10, 0);
+        // APC: ESC _ <payload> ESC \\
+        p.process(b"\x1b_xyz\x1b\\hello");
+        let mut buf = String::new();
+        for col in 0..10 {
+            let cell = p.screen().cell(0, col).unwrap();
+            if cell.contents().is_empty() {
+                buf.push(' ');
+            } else {
+                buf.push_str(cell.contents());
+            }
+        }
+        assert!(
+            !buf.contains('\u{1b}') && !buf.contains('_'),
+            "APC bled through into cells: {buf:?}"
+        );
+        assert!(buf.starts_with("hello"));
+    }
+
+    #[test]
+    fn mouse_decset_1000_then_1006() {
+        let mut p = Parser::new(2, 10, 0);
+        p.process(b"\x1b[?1000h\x1b[?1006h");
+        assert_eq!(
+            p.screen().mouse_protocol_mode(),
+            MouseProtocolMode::PressRelease
+        );
+        assert_eq!(
+            p.screen().mouse_protocol_encoding(),
+            MouseProtocolEncoding::Sgr
+        );
+    }
+
+    #[test]
+    fn cursor_position_after_writes() {
+        let mut p = Parser::new(3, 10, 0);
+        p.process(b"abc");
+        assert_eq!(p.screen().cursor_position(), (0, 3));
+    }
+
+    #[test]
+    fn resize_updates_dimensions() {
+        let mut p = Parser::new(2, 4, 0);
+        p.process(b"hi");
+        p.screen_mut().set_size(4, 8);
+        assert_eq!(p.screen().size(), (4, 8));
+    }
+
+    #[test]
+    fn alt_screen_content_is_reachable_via_cell() {
+        let mut p = Parser::new(5, 20, 0);
+        // Mimic what curses apps (mc, vim) do on startup: switch to alt
+        // screen, clear, then draw. Reading cells must reflect what's on
+        // the alt screen, not the primary one.
+        p.process(b"\x1b[?1049h\x1b[2J\x1b[Hhello world");
+        let s = p.screen();
+        let mut row0 = String::new();
+        for col in 0..20 {
+            let c = s.cell(0, col).unwrap();
+            if c.contents().is_empty() {
+                row0.push(' ');
+            } else {
+                row0.push_str(c.contents());
+            }
+        }
+        assert!(
+            row0.starts_with("hello world"),
+            "expected alt-screen content visible, got {row0:?}"
+        );
+    }
+
+    #[test]
+    fn da_query_produces_pty_writeback() {
+        let mut p = Parser::new(2, 10, 0);
+        // Primary Device Attributes query.
+        p.process(b"\x1b[c");
+        let pending = p.take_pending_writes();
+        assert!(
+            !pending.is_empty(),
+            "expected DA reply queued; got nothing — alacritty proxy not capturing PtyWrite"
+        );
+    }
+}

--- a/src/emu.rs
+++ b/src/emu.rs
@@ -57,17 +57,12 @@ impl Color {
     }
 }
 
-/// Mouse reporting mode the inner app has DECSET'd.
-///
-/// `Press` is exposed for protocol parity with the original `vt100`-based
-/// surface (and the `tu mouse state` JSON), but in practice alacritty does
-/// not separately track X10 press-only mode — anything that turns on click
-/// reporting is treated as press+release.
+/// Mouse reporting mode the inner app has DECSET'd. Alacritty does not
+/// separately track X10 press-only mode — anything that turns on click
+/// reporting is reported here as `PressRelease`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
 pub enum MouseProtocolMode {
     None,
-    Press,
     PressRelease,
     ButtonMotion,
     AnyMotion,
@@ -274,6 +269,30 @@ impl<'a> Screen<'a> {
 
     pub fn size(&self) -> (u16, u16) {
         (self.parser.rows, self.parser.cols)
+    }
+
+    /// Visible-screen text as one `String` per row, with one Unicode character
+    /// per terminal column. Wide-char continuation cells are emitted as `' '`
+    /// so `chars().count()` of any row equals the terminal's column count —
+    /// downstream code that maps byte / char offsets to screen columns
+    /// (text targeting, regex matching, wait-for-text) won't drift.
+    pub fn text_rows(&self) -> Vec<String> {
+        let (rows, cols) = self.size();
+        let mut out = Vec::with_capacity(rows as usize);
+        for r in 0..rows {
+            let mut line = String::new();
+            for c in 0..cols {
+                let cell = self.cell(r, c);
+                match cell {
+                    Some(cell) if cell.is_wide_continuation() => line.push(' '),
+                    Some(cell) if cell.contents().is_empty() => line.push(' '),
+                    Some(cell) => line.push_str(cell.contents()),
+                    None => line.push(' '),
+                }
+            }
+            out.push(line);
+        }
+        out
     }
 
     /// Plain-text dump of visible screen + scrollback, line by line.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod daemon;
+mod emu;
 mod keys;
 mod mouse;
 mod output;

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,10 @@ enum Command {
         /// Font size in pixels (used with --png).
         #[arg(long, default_value = "14", value_parser = parse_font_size)]
         font_size: f32,
+
+        /// Suppress the synthetic mouse-cursor overlay (used with --png).
+        #[arg(long)]
+        no_cursor: bool,
     },
 
     /// Print cursor position as row,col.
@@ -321,9 +325,11 @@ async fn main() {
             stdout,
             font,
             font_size,
+            no_cursor,
         } => {
             if png {
-                commands::screenshot::run_png(name, output, stdout, font, font_size).await
+                commands::screenshot::run_png(name, output, stdout, font, font_size, !no_cursor)
+                    .await
             } else {
                 commands::screenshot::run_text(name, format).await
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod daemon;
 mod keys;
+mod mouse;
 mod output;
 mod paths;
 mod pty;
@@ -195,6 +196,12 @@ enum Command {
         timeout: u64,
     },
 
+    /// Mouse input: click, drag, move, scroll, state.
+    Mouse {
+        #[command(subcommand)]
+        action: commands::mouse::MouseCmd,
+    },
+
     /// Live read-only view of a session.
     Monitor {
         /// Session name (default: "default").
@@ -342,6 +349,8 @@ async fn main() {
         } => commands::wait::run(name, stable, text, timeout).await,
 
         Command::Monitor { name } => commands::monitor::run(name).await,
+
+        Command::Mouse { action } => commands::mouse::run(action, format).await,
     };
 
     if let Err(e) = result {

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -1,0 +1,555 @@
+//! Mouse-event encoding for xterm-style mouse protocols, plus helpers to
+//! resolve text/regex targets against the visible screen.
+//!
+//! Wire format support: SGR (DECSET 1006), Default legacy (DECSET 1000), and
+//! UTF-8 (DECSET 1005). The inner application's `DECSET 100x` enables a mode;
+//! `vt100`'s `screen.mouse_protocol_mode()` / `mouse_protocol_encoding()` tells
+//! us which one to emit.
+//!
+//! Coordinates on the public/CLI surface are 0-based (matching `cursor` /
+//! `screenshot`). Wire formats are 1-based; we add 1 at encode time.
+
+use anyhow::{anyhow, bail, Result};
+use regex::Regex;
+
+use crate::daemon::protocol::{MouseButton, MouseEncoding, MouseMods, ScrollDir};
+
+/// One low-level wire event ready to encode.
+#[derive(Debug, Clone, Copy)]
+pub enum WireEvent {
+    /// Button press at (col, row), 0-based.
+    Down {
+        col: u16,
+        row: u16,
+        button: MouseButton,
+        mods: MouseMods,
+    },
+    /// Button release at (col, row), 0-based.
+    Up {
+        col: u16,
+        row: u16,
+        button: MouseButton,
+        mods: MouseMods,
+    },
+    /// Bare move (AnyMotion) — no button held.
+    Move { col: u16, row: u16, mods: MouseMods },
+    /// Move while button is held (drag).
+    DragMove {
+        col: u16,
+        row: u16,
+        button: MouseButton,
+        mods: MouseMods,
+    },
+    /// Wheel notch.
+    Scroll {
+        col: u16,
+        row: u16,
+        dir: ScrollDir,
+        mods: MouseMods,
+    },
+}
+
+fn button_low_bits(button: MouseButton) -> u32 {
+    match button {
+        MouseButton::Left => 0,
+        MouseButton::Middle => 1,
+        MouseButton::Right => 2,
+    }
+}
+
+fn mods_bits(mods: MouseMods) -> u32 {
+    let mut b = 0u32;
+    if mods.shift {
+        b |= 4;
+    }
+    if mods.alt {
+        b |= 8;
+    }
+    if mods.ctrl {
+        b |= 16;
+    }
+    b
+}
+
+fn scroll_low_bits(dir: ScrollDir) -> u32 {
+    // Scroll events use the high bit (64) plus a direction code.
+    match dir {
+        ScrollDir::Up => 0,
+        ScrollDir::Down => 1,
+        ScrollDir::Left => 2,
+        ScrollDir::Right => 3,
+    }
+}
+
+/// Compute the SGR `<button>` parameter (which is also the byte-32 base for
+/// legacy encodings). Bit 5 (32) marks motion; bit 6 (64) marks wheel.
+fn sgr_button(event: &WireEvent) -> u32 {
+    match event {
+        WireEvent::Down { button, mods, .. } | WireEvent::Up { button, mods, .. } => {
+            button_low_bits(*button) | mods_bits(*mods)
+        }
+        WireEvent::Move { mods, .. } => {
+            // bare move: motion bit + "no button" sentinel (3 in low bits).
+            32 | 3 | mods_bits(*mods)
+        }
+        WireEvent::DragMove { button, mods, .. } => {
+            32 | button_low_bits(*button) | mods_bits(*mods)
+        }
+        WireEvent::Scroll { dir, mods, .. } => 64 | scroll_low_bits(*dir) | mods_bits(*mods),
+    }
+}
+
+fn coords(event: &WireEvent) -> (u16, u16) {
+    match event {
+        WireEvent::Down { col, row, .. }
+        | WireEvent::Up { col, row, .. }
+        | WireEvent::Move { col, row, .. }
+        | WireEvent::DragMove { col, row, .. }
+        | WireEvent::Scroll { col, row, .. } => (*col, *row),
+    }
+}
+
+fn is_release(event: &WireEvent) -> bool {
+    matches!(event, WireEvent::Up { .. })
+}
+
+/// Encode a sequence of events into bytes ready to write to the PTY master.
+///
+/// Errors if the chosen encoding cannot represent the event (e.g. legacy
+/// encoding tops out at col/row 223).
+pub fn encode(events: &[WireEvent], encoding: MouseEncoding) -> Result<Vec<u8>> {
+    let mut out = Vec::with_capacity(events.len() * 12);
+    for ev in events {
+        match encoding {
+            MouseEncoding::Sgr => encode_sgr(ev, &mut out),
+            MouseEncoding::Default => encode_default(ev, &mut out)?,
+            MouseEncoding::Utf8 => encode_utf8(ev, &mut out)?,
+        }
+    }
+    Ok(out)
+}
+
+fn encode_sgr(event: &WireEvent, out: &mut Vec<u8>) {
+    let (col, row) = coords(event);
+    let cb = sgr_button(event);
+    let final_byte = if is_release(event) { 'm' } else { 'M' };
+    out.extend_from_slice(
+        format!(
+            "\x1b[<{};{};{}{}",
+            cb,
+            col as u32 + 1,
+            row as u32 + 1,
+            final_byte
+        )
+        .as_bytes(),
+    );
+}
+
+/// Legacy `CSI M Cb Cx Cy` encoding (DECSET 1000/1002 without SGR).
+///
+/// Each parameter is a single byte = `value + 32`. Releases are encoded with
+/// button code `3` (the protocol can't distinguish *which* button was released).
+fn encode_default(event: &WireEvent, out: &mut Vec<u8>) -> Result<()> {
+    let (col, row) = coords(event);
+    let cb = if is_release(event) {
+        // Legacy: any release becomes button 3, plus modifiers.
+        3 | match event {
+            WireEvent::Up { mods, .. } => mods_bits(*mods),
+            _ => 0,
+        }
+    } else {
+        sgr_button(event)
+    };
+
+    let cx = col as u32 + 1;
+    let cy = row as u32 + 1;
+    if cx > 223 || cy > 223 {
+        bail!(
+            "legacy mouse encoding cannot represent col={} row={} (max 223). \
+             The inner app should enable SGR (DECSET 1006).",
+            col,
+            row
+        );
+    }
+    if cb > 223 {
+        bail!("legacy mouse encoding overflowed the button byte");
+    }
+
+    out.extend_from_slice(b"\x1b[M");
+    out.push((cb + 32) as u8);
+    out.push((cx + 32) as u8);
+    out.push((cy + 32) as u8);
+    Ok(())
+}
+
+/// UTF-8 encoding (DECSET 1005): same as legacy but Cx/Cy may exceed 223 by
+/// being encoded as UTF-8 codepoints. Cb is still a single byte.
+fn encode_utf8(event: &WireEvent, out: &mut Vec<u8>) -> Result<()> {
+    let (col, row) = coords(event);
+    let cb = if is_release(event) {
+        3 | match event {
+            WireEvent::Up { mods, .. } => mods_bits(*mods),
+            _ => 0,
+        }
+    } else {
+        sgr_button(event)
+    };
+
+    if cb > 223 {
+        bail!("UTF-8 mouse encoding overflowed the button byte");
+    }
+
+    out.extend_from_slice(b"\x1b[M");
+    out.push((cb + 32) as u8);
+    push_utf8_coord(out, col as u32 + 1)?;
+    push_utf8_coord(out, row as u32 + 1)?;
+    Ok(())
+}
+
+fn push_utf8_coord(out: &mut Vec<u8>, value: u32) -> Result<()> {
+    let cp = value
+        .checked_add(32)
+        .ok_or_else(|| anyhow!("mouse coordinate overflow"))?;
+    let ch = char::from_u32(cp).ok_or_else(|| anyhow!("invalid utf-8 mouse coordinate {cp}"))?;
+    let mut buf = [0u8; 4];
+    out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+    Ok(())
+}
+
+/// Parse a comma-separated modifier string (`"Ctrl,Shift"`, case-insensitive).
+pub fn parse_mods(s: &str) -> Result<MouseMods> {
+    let mut mods = MouseMods::default();
+    if s.is_empty() {
+        return Ok(mods);
+    }
+    for part in s.split(',') {
+        let token = part.trim().to_lowercase();
+        match token.as_str() {
+            "" => continue,
+            "shift" => mods.shift = true,
+            "ctrl" | "control" => mods.ctrl = true,
+            "alt" | "meta" => mods.alt = true,
+            "super" | "hyper" | "cmd" | "command" | "win" => {
+                bail!(
+                    "modifier {part:?} is not representable in the xterm mouse protocol \
+                     (only Ctrl, Shift, Alt are supported)"
+                )
+            }
+            _ => bail!("unknown modifier {part:?}. Valid: Ctrl, Shift, Alt"),
+        }
+    }
+    Ok(mods)
+}
+
+/// Parse `--button left|right|middle` (case-insensitive).
+pub fn parse_button(s: &str) -> Result<MouseButton, String> {
+    match s.to_lowercase().as_str() {
+        "left" | "l" => Ok(MouseButton::Left),
+        "right" | "r" => Ok(MouseButton::Right),
+        "middle" | "m" => Ok(MouseButton::Middle),
+        _ => Err(format!("invalid --button {s:?}. Use left|right|middle")),
+    }
+}
+
+/// Parse `up|down|left|right` for scroll direction.
+pub fn parse_scroll_dir(s: &str) -> Result<ScrollDir, String> {
+    match s.to_lowercase().as_str() {
+        "up" | "u" => Ok(ScrollDir::Up),
+        "down" | "d" => Ok(ScrollDir::Down),
+        "left" | "l" => Ok(ScrollDir::Left),
+        "right" | "r" => Ok(ScrollDir::Right),
+        _ => Err(format!(
+            "invalid scroll direction {s:?}. Use up|down|left|right"
+        )),
+    }
+}
+
+/// One match found on the visible screen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScreenMatch {
+    pub row: u16,
+    pub col_start: u16,
+    pub col_end: u16, // exclusive
+}
+
+impl ScreenMatch {
+    pub fn center(self) -> (u16, u16) {
+        let len = self.col_end.saturating_sub(self.col_start);
+        let mid = self.col_start + len / 2;
+        (mid, self.row)
+    }
+}
+
+/// Find every line-confined occurrence of `needle` in the rendered screen.
+///
+/// `screen_rows` is one string per visible row (no trailing newline).
+pub fn find_text(screen_rows: &[String], needle: &str) -> Vec<ScreenMatch> {
+    if needle.is_empty() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    for (row_idx, line) in screen_rows.iter().enumerate() {
+        let mut search_from = 0usize;
+        while let Some(byte_idx) = line[search_from..].find(needle) {
+            let start_byte = search_from + byte_idx;
+            let end_byte = start_byte + needle.len();
+            // Convert byte offset to char column. Visible cells map 1:1 to chars
+            // because vt100 emits each cell as one character.
+            let col_start = line[..start_byte].chars().count() as u16;
+            let col_end = line[..end_byte].chars().count() as u16;
+            out.push(ScreenMatch {
+                row: row_idx as u16,
+                col_start,
+                col_end,
+            });
+            search_from = end_byte.max(start_byte + 1);
+        }
+    }
+    out
+}
+
+/// Find every regex match in the rendered screen, line by line.
+pub fn find_regex(screen_rows: &[String], pattern: &str) -> Result<Vec<ScreenMatch>> {
+    let re = Regex::new(pattern).map_err(|e| anyhow!("invalid regex {pattern:?}: {e}"))?;
+    let mut out = Vec::new();
+    for (row_idx, line) in screen_rows.iter().enumerate() {
+        for m in re.find_iter(line) {
+            let col_start = line[..m.start()].chars().count() as u16;
+            let col_end = line[..m.end()].chars().count() as u16;
+            out.push(ScreenMatch {
+                row: row_idx as u16,
+                col_start,
+                col_end,
+            });
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dn(col: u16, row: u16) -> WireEvent {
+        WireEvent::Down {
+            col,
+            row,
+            button: MouseButton::Left,
+            mods: MouseMods::default(),
+        }
+    }
+    fn up(col: u16, row: u16) -> WireEvent {
+        WireEvent::Up {
+            col,
+            row,
+            button: MouseButton::Left,
+            mods: MouseMods::default(),
+        }
+    }
+
+    #[test]
+    fn sgr_left_click_press_then_release() {
+        let bytes = encode(&[dn(49, 19), up(49, 19)], MouseEncoding::Sgr).unwrap();
+        // 0-based 49,19 → 1-based 50,20. Left = 0.
+        assert_eq!(bytes, b"\x1b[<0;50;20M\x1b[<0;50;20m");
+    }
+
+    #[test]
+    fn sgr_right_button_with_ctrl_shift() {
+        let ev = WireEvent::Down {
+            col: 0,
+            row: 0,
+            button: MouseButton::Right,
+            mods: MouseMods {
+                shift: true,
+                alt: false,
+                ctrl: true,
+            },
+        };
+        // right=2, shift=4, ctrl=16 → 22; coords 1,1 (1-based)
+        let bytes = encode(&[ev], MouseEncoding::Sgr).unwrap();
+        assert_eq!(bytes, b"\x1b[<22;1;1M");
+    }
+
+    #[test]
+    fn sgr_middle_button() {
+        let ev = WireEvent::Down {
+            col: 9,
+            row: 4,
+            button: MouseButton::Middle,
+            mods: MouseMods::default(),
+        };
+        let bytes = encode(&[ev], MouseEncoding::Sgr).unwrap();
+        assert_eq!(bytes, b"\x1b[<1;10;5M");
+    }
+
+    #[test]
+    fn sgr_drag_move_sets_motion_bit() {
+        let ev = WireEvent::DragMove {
+            col: 4,
+            row: 4,
+            button: MouseButton::Left,
+            mods: MouseMods::default(),
+        };
+        // motion(32) | left(0) = 32
+        let bytes = encode(&[ev], MouseEncoding::Sgr).unwrap();
+        assert_eq!(bytes, b"\x1b[<32;5;5M");
+    }
+
+    #[test]
+    fn sgr_bare_move_uses_button_3() {
+        let ev = WireEvent::Move {
+            col: 0,
+            row: 0,
+            mods: MouseMods::default(),
+        };
+        // motion(32) | nobutton(3) = 35
+        let bytes = encode(&[ev], MouseEncoding::Sgr).unwrap();
+        assert_eq!(bytes, b"\x1b[<35;1;1M");
+    }
+
+    #[test]
+    fn sgr_scroll_directions() {
+        let mk = |dir| WireEvent::Scroll {
+            col: 0,
+            row: 0,
+            dir,
+            mods: MouseMods::default(),
+        };
+        let up = encode(&[mk(ScrollDir::Up)], MouseEncoding::Sgr).unwrap();
+        let down = encode(&[mk(ScrollDir::Down)], MouseEncoding::Sgr).unwrap();
+        let left = encode(&[mk(ScrollDir::Left)], MouseEncoding::Sgr).unwrap();
+        let right = encode(&[mk(ScrollDir::Right)], MouseEncoding::Sgr).unwrap();
+        assert_eq!(up, b"\x1b[<64;1;1M");
+        assert_eq!(down, b"\x1b[<65;1;1M");
+        assert_eq!(left, b"\x1b[<66;1;1M");
+        assert_eq!(right, b"\x1b[<67;1;1M");
+    }
+
+    #[test]
+    fn default_legacy_encoding_press() {
+        let bytes = encode(&[dn(0, 0)], MouseEncoding::Default).unwrap();
+        // Cb=0+32=32 (' '), Cx=1+32=33 ('!'), Cy=1+32=33 ('!')
+        assert_eq!(bytes, b"\x1b[M !!");
+    }
+
+    #[test]
+    fn default_legacy_release_uses_button_3() {
+        let bytes = encode(&[up(0, 0)], MouseEncoding::Default).unwrap();
+        // Cb = 3 + 32 = 35 ('#')
+        assert_eq!(bytes, b"\x1b[M#!!");
+    }
+
+    #[test]
+    fn default_encoding_rejects_overflow() {
+        let err = encode(&[dn(300, 0)], MouseEncoding::Default).unwrap_err();
+        assert!(err.to_string().contains("legacy"));
+    }
+
+    #[test]
+    fn utf8_encoding_handles_high_coords() {
+        // col=300 → 301 → 333 codepoint = ǌ-ish; just round-trip the bytes.
+        let bytes = encode(&[dn(300, 0)], MouseEncoding::Utf8).unwrap();
+        // First three bytes are CSI M, then Cb=' ', then UTF-8 of (300+1+32)=333,
+        // then UTF-8 of (0+1+32)=33.
+        assert!(bytes.starts_with(b"\x1b[M "));
+        let mut buf = [0u8; 4];
+        let cx_bytes = char::from_u32(333).unwrap().encode_utf8(&mut buf).len();
+        assert_eq!(
+            &bytes[4..4 + cx_bytes],
+            char::from_u32(333).unwrap().to_string().as_bytes()
+        );
+        assert_eq!(bytes[4 + cx_bytes], b'!');
+    }
+
+    #[test]
+    fn parse_mods_accepts_known_combos() {
+        assert_eq!(parse_mods("").unwrap(), MouseMods::default());
+        let m = parse_mods("Ctrl,Shift").unwrap();
+        assert!(m.ctrl && m.shift && !m.alt);
+        let m = parse_mods("alt").unwrap();
+        assert!(m.alt);
+        let m = parse_mods("CTRL, ALT , SHIFT").unwrap();
+        assert!(m.ctrl && m.alt && m.shift);
+    }
+
+    #[test]
+    fn parse_mods_rejects_unknown() {
+        assert!(parse_mods("Hyper").is_err());
+        assert!(parse_mods("super").is_err());
+        assert!(parse_mods("foobar").is_err());
+    }
+
+    #[test]
+    fn parse_button_variants() {
+        assert_eq!(parse_button("left").unwrap(), MouseButton::Left);
+        assert_eq!(parse_button("RIGHT").unwrap(), MouseButton::Right);
+        assert_eq!(parse_button("Middle").unwrap(), MouseButton::Middle);
+        assert!(parse_button("foo").is_err());
+    }
+
+    #[test]
+    fn screen_match_center_handles_odd_and_even_widths() {
+        assert_eq!(
+            ScreenMatch {
+                row: 3,
+                col_start: 10,
+                col_end: 13
+            }
+            .center(),
+            (11, 3)
+        );
+        // even: 10..14 (length 4) → midpoint at 10 + 4/2 = 12
+        assert_eq!(
+            ScreenMatch {
+                row: 3,
+                col_start: 10,
+                col_end: 14
+            }
+            .center(),
+            (12, 3)
+        );
+    }
+
+    #[test]
+    fn find_text_basic() {
+        let rows = vec![
+            "  Buy upgrade  ".to_string(),
+            "no match here".to_string(),
+            "  Buy upgrade".to_string(),
+        ];
+        let hits = find_text(&rows, "Buy upgrade");
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].row, 0);
+        assert_eq!(hits[0].col_start, 2);
+        assert_eq!(hits[0].col_end, 13);
+        assert_eq!(hits[1].row, 2);
+    }
+
+    #[test]
+    fn find_text_overlapping_does_not_loop() {
+        let rows = vec!["aaaa".to_string()];
+        let hits = find_text(&rows, "aa");
+        // Non-overlapping at byte offsets 0, 2.
+        assert_eq!(hits.len(), 2);
+    }
+
+    #[test]
+    fn find_text_empty_needle_returns_empty() {
+        let rows = vec!["hello".to_string()];
+        assert!(find_text(&rows, "").is_empty());
+    }
+
+    #[test]
+    fn find_regex_extracts_matches_per_line() {
+        let rows = vec![
+            "Buy 10 carrots".to_string(),
+            "Buy 250 turnips".to_string(),
+            "Sell 5".to_string(),
+        ];
+        let hits = find_regex(&rows, r"Buy\s+\d+").unwrap();
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].col_start, 0);
+        assert_eq!(hits[1].row, 1);
+    }
+}

--- a/src/pty/spawn.rs
+++ b/src/pty/spawn.rs
@@ -42,6 +42,20 @@ pub fn spawn(
         | termios::LocalFlags::ICANON
         | termios::LocalFlags::ISIG
         | termios::LocalFlags::IEXTEN;
+    // Disable ECHOCTL (control-character caret-notation echoing). With
+    // ECHOCTL on (macOS default for openpty), an input byte like 0x1B (ESC)
+    // is echoed back as the two printable characters `^[`. That's mostly
+    // harmless until an app like Midnight Commander writes its own ESC
+    // sequences to a child shell PTY: mc's "persistent command buffer"
+    // feature sends ESC `_` to trigger a zsh widget, then reads back the
+    // echo expecting it to come through as raw bytes for its
+    // `strip_ctrl_codes` filter. With ECHOCTL on, the echo is already
+    // caret-notation printable text — strip_ctrl_codes can't strip it,
+    // and the literal `^[_` gets baked into mc's prompt cache. Real
+    // terminals end up with ECHOCTL off by the time interactive shells
+    // run because the user's shell init (or zsh itself) disables it; we
+    // start from openpty's defaults, so we have to do it ourselves.
+    termios.local_flags &= !termios::LocalFlags::ECHOCTL;
     termios.input_flags |= termios::InputFlags::ICRNL;
     termios.output_flags |= termios::OutputFlags::OPOST | termios::OutputFlags::ONLCR;
     termios::tcsetattr(&slave, termios::SetArg::TCSANOW, &termios).context("tcsetattr failed")?;

--- a/src/render/image.rs
+++ b/src/render/image.rs
@@ -30,6 +30,12 @@ pub struct ScreenshotConfig {
     pub font_path: Option<String>,
     pub font_size: f32,
     pub line_height: f32,
+    /// If `Some((col, row))` (0-based), paint a magenta overlay on that cell to
+    /// show tu's synthetic mouse cursor.
+    pub mouse_cursor: Option<(u16, u16)>,
+    /// When `mouse_cursor` is set: `true` paints a filled magenta block (a
+    /// button is currently held), `false` paints just an outline (idle cursor).
+    pub mouse_held: bool,
 }
 
 impl Default for ScreenshotConfig {
@@ -38,6 +44,8 @@ impl Default for ScreenshotConfig {
             font_path: None,
             font_size: 14.0,
             line_height: 1.2,
+            mouse_cursor: None,
+            mouse_held: false,
         }
     }
 }
@@ -70,6 +78,15 @@ impl Screenshot {
     /// Override the font size in pixels (default: 14.0).
     pub fn font_size(mut self, size: f32) -> Self {
         self.config.font_size = size;
+        self
+    }
+
+    /// Paint a magenta overlay on the given cell to show tu's synthetic mouse
+    /// cursor. `held = true` draws a filled block (button held), `false` draws
+    /// an outline (idle cursor).
+    pub fn mouse_cursor(mut self, col: u16, row: u16, held: bool) -> Self {
+        self.config.mouse_cursor = Some((col, row));
+        self.config.mouse_held = held;
         self
     }
 
@@ -202,7 +219,72 @@ fn render_screen(screen: &ScreenSnapshot, config: &ScreenshotConfig) -> Result<R
         }
     }
 
+    if let Some((cur_col, cur_row)) = config.mouse_cursor {
+        if cur_col < screen.cols() && cur_row < screen.rows() {
+            paint_mouse_cursor(
+                &mut image,
+                cur_col,
+                cur_row,
+                char_width,
+                line_height,
+                config.mouse_held,
+            );
+        }
+    }
+
     Ok(image)
+}
+
+/// tu's signature mouse-cursor magenta. Bright enough to spot at a glance,
+/// uncommon enough to avoid colliding with typical TUI palettes.
+const MOUSE_CURSOR_RGBA: Rgba<u8> = Rgba([255, 0, 200, 255]);
+
+/// Paint the synthetic mouse cursor at the given cell. `held` swaps an outline
+/// for a filled block to signal that a button is currently down.
+fn paint_mouse_cursor(
+    image: &mut RgbaImage,
+    cur_col: u16,
+    cur_row: u16,
+    char_width: f32,
+    line_height: f32,
+    held: bool,
+) {
+    let x = (cur_col as f32 * char_width).round() as i32;
+    let y = (cur_row as f32 * line_height).round() as i32;
+    let w = char_width.ceil() as u32;
+    let h = line_height.ceil() as u32;
+
+    if held {
+        // Filled block.
+        draw_filled_rect_mut(image, Rect::at(x, y).of_size(w, h), MOUSE_CURSOR_RGBA);
+    } else {
+        // 2-px outline so the underlying cell stays readable.
+        let thickness = 2u32.min(w.min(h).max(1));
+        // Top
+        draw_filled_rect_mut(
+            image,
+            Rect::at(x, y).of_size(w, thickness),
+            MOUSE_CURSOR_RGBA,
+        );
+        // Bottom
+        draw_filled_rect_mut(
+            image,
+            Rect::at(x, y + h.saturating_sub(thickness) as i32).of_size(w, thickness),
+            MOUSE_CURSOR_RGBA,
+        );
+        // Left
+        draw_filled_rect_mut(
+            image,
+            Rect::at(x, y).of_size(thickness, h),
+            MOUSE_CURSOR_RGBA,
+        );
+        // Right
+        draw_filled_rect_mut(
+            image,
+            Rect::at(x + w.saturating_sub(thickness) as i32, y).of_size(thickness, h),
+            MOUSE_CURSOR_RGBA,
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/render/image.rs
+++ b/src/render/image.rs
@@ -227,6 +227,8 @@ fn render_screen(screen: &ScreenSnapshot, config: &ScreenshotConfig) -> Result<R
                 cur_row,
                 char_width,
                 line_height,
+                scale,
+                &font,
                 config.mouse_held,
             );
         }
@@ -238,15 +240,20 @@ fn render_screen(screen: &ScreenSnapshot, config: &ScreenshotConfig) -> Result<R
 /// tu's signature mouse-cursor magenta. Bright enough to spot at a glance,
 /// uncommon enough to avoid colliding with typical TUI palettes.
 const MOUSE_CURSOR_RGBA: Rgba<u8> = Rgba([255, 0, 200, 255]);
+const MOUSE_CURSOR_HELD_FG: Rgba<u8> = Rgba([255, 255, 255, 255]);
 
-/// Paint the synthetic mouse cursor at the given cell. `held` swaps an outline
-/// for a filled block to signal that a button is currently down.
+/// Paint the synthetic mouse cursor at the given cell as a triangular caret
+/// glyph (`^`). Idle = magenta `^` on the existing background; held =
+/// bright-white `^` on a filled magenta cell, so a held button is unmistakable.
+#[allow(clippy::too_many_arguments)]
 fn paint_mouse_cursor(
     image: &mut RgbaImage,
     cur_col: u16,
     cur_row: u16,
     char_width: f32,
     line_height: f32,
+    scale: PxScale,
+    font: &FontRef<'_>,
     held: bool,
 ) {
     let x = (cur_col as f32 * char_width).round() as i32;
@@ -254,37 +261,16 @@ fn paint_mouse_cursor(
     let w = char_width.ceil() as u32;
     let h = line_height.ceil() as u32;
 
-    if held {
-        // Filled block.
+    let glyph_color = if held {
+        // Magenta cell behind a bright-white caret.
         draw_filled_rect_mut(image, Rect::at(x, y).of_size(w, h), MOUSE_CURSOR_RGBA);
+        MOUSE_CURSOR_HELD_FG
     } else {
-        // 2-px outline so the underlying cell stays readable.
-        let thickness = 2u32.min(w.min(h).max(1));
-        // Top
-        draw_filled_rect_mut(
-            image,
-            Rect::at(x, y).of_size(w, thickness),
-            MOUSE_CURSOR_RGBA,
-        );
-        // Bottom
-        draw_filled_rect_mut(
-            image,
-            Rect::at(x, y + h.saturating_sub(thickness) as i32).of_size(w, thickness),
-            MOUSE_CURSOR_RGBA,
-        );
-        // Left
-        draw_filled_rect_mut(
-            image,
-            Rect::at(x, y).of_size(thickness, h),
-            MOUSE_CURSOR_RGBA,
-        );
-        // Right
-        draw_filled_rect_mut(
-            image,
-            Rect::at(x + w.saturating_sub(thickness) as i32, y).of_size(thickness, h),
-            MOUSE_CURSOR_RGBA,
-        );
-    }
+        // Caret on top of whatever the inner app drew.
+        MOUSE_CURSOR_RGBA
+    };
+
+    draw_text_mut(image, glyph_color, x, y, scale, font, "^");
 }
 
 #[cfg(test)]

--- a/src/render/image.rs
+++ b/src/render/image.rs
@@ -242,9 +242,9 @@ fn render_screen(screen: &ScreenSnapshot, config: &ScreenshotConfig) -> Result<R
 const MOUSE_CURSOR_RGBA: Rgba<u8> = Rgba([255, 0, 200, 255]);
 const MOUSE_CURSOR_HELD_FG: Rgba<u8> = Rgba([255, 255, 255, 255]);
 
-/// Paint the synthetic mouse cursor at the given cell as a triangular caret
-/// glyph (`^`). Idle = magenta `^` on the existing background; held =
-/// bright-white `^` on a filled magenta cell, so a held button is unmistakable.
+/// Paint the synthetic mouse cursor at the given cell as a triangle glyph
+/// (`△`). Idle = magenta `△` on the existing background; held =
+/// bright-white `△` on a filled magenta cell, so a held button is unmistakable.
 #[allow(clippy::too_many_arguments)]
 fn paint_mouse_cursor(
     image: &mut RgbaImage,
@@ -262,15 +262,15 @@ fn paint_mouse_cursor(
     let h = line_height.ceil() as u32;
 
     let glyph_color = if held {
-        // Magenta cell behind a bright-white caret.
+        // Magenta cell behind a bright-white glyph.
         draw_filled_rect_mut(image, Rect::at(x, y).of_size(w, h), MOUSE_CURSOR_RGBA);
         MOUSE_CURSOR_HELD_FG
     } else {
-        // Caret on top of whatever the inner app drew.
+        // Glyph on top of whatever the inner app drew.
         MOUSE_CURSOR_RGBA
     };
 
-    draw_text_mut(image, glyph_color, x, y, scale, font, "^");
+    draw_text_mut(image, glyph_color, x, y, scale, font, "△");
 }
 
 #[cfg(test)]

--- a/src/render/image.rs
+++ b/src/render/image.rs
@@ -282,7 +282,7 @@ mod tests {
 
     #[test]
     fn saves_png() {
-        let mut parser = vt100::Parser::new(4, 20, 0);
+        let mut parser = crate::emu::Parser::new(4, 20, 0);
         parser.process(b"\x1b[32mhello\x1b[0m");
         let screenshot = Screenshot::new(ScreenSnapshot::from_vt100(parser.screen()));
 
@@ -304,7 +304,7 @@ mod tests {
 
     #[test]
     fn rejects_invalid_font_size() {
-        let mut parser = vt100::Parser::new(2, 4, 0);
+        let mut parser = crate::emu::Parser::new(2, 4, 0);
         parser.process(b"hi");
         let screenshot =
             Screenshot::new(ScreenSnapshot::from_vt100(parser.screen())).font_size(0.0);

--- a/src/render/screen.rs
+++ b/src/render/screen.rs
@@ -1,4 +1,4 @@
-/// Terminal color value, decoupled from `vt100::Color` so it can be owned, cloned, and
+/// Terminal color value, decoupled from `crate::emu::Color` so it can be owned, cloned, and
 /// used outside of a parser borrow.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Color {
@@ -10,12 +10,12 @@ pub enum Color {
     Rgb(u8, u8, u8),
 }
 
-impl From<vt100::Color> for Color {
-    fn from(value: vt100::Color) -> Self {
+impl From<crate::emu::Color> for Color {
+    fn from(value: crate::emu::Color) -> Self {
         match value {
-            vt100::Color::Default => Self::Default,
-            vt100::Color::Idx(idx) => Self::Indexed(idx),
-            vt100::Color::Rgb(r, g, b) => Self::Rgb(r, g, b),
+            crate::emu::Color::Default => Self::Default,
+            crate::emu::Color::Idx(idx) => Self::Indexed(idx),
+            crate::emu::Color::Rgb(r, g, b) => Self::Rgb(r, g, b),
         }
     }
 }
@@ -64,7 +64,7 @@ impl Default for Cell {
 /// An owned, `Send`-safe snapshot of the vt100 emulator's visible screen.
 ///
 /// This is the abstraction boundary between the daemon's parser (which holds a borrowed,
-/// non-`Send` `vt100::Screen`) and the render pipeline. Construct via
+/// non-`Send` `crate::emu::Screen`) and the render pipeline. Construct via
 /// [`ScreenSnapshot::from_vt100`], then pass to the text or image renderers.
 ///
 /// The grid is stored row-major: `cells[row][col]`. Dimensions are guaranteed to match
@@ -82,7 +82,7 @@ impl ScreenSnapshot {
     /// Iterates every cell in the visible area and copies its content, colors, and
     /// attributes. Cells that the parser reports as `None` (which shouldn't happen
     /// for in-bounds coordinates) are replaced with [`Cell::default`].
-    pub fn from_vt100(screen: &vt100::Screen) -> Self {
+    pub fn from_vt100(screen: crate::emu::Screen<'_>) -> Self {
         let (rows, cols) = screen.size();
         let mut cells = Vec::with_capacity(rows as usize);
 
@@ -132,7 +132,7 @@ mod tests {
 
     #[test]
     fn builds_snapshot_from_vt100_screen() {
-        let mut parser = vt100::Parser::new(4, 10, 0);
+        let mut parser = crate::emu::Parser::new(4, 10, 0);
         parser.process(b"\x1b[31mA\x1b[7mB\x1b[0m");
 
         let snapshot = ScreenSnapshot::from_vt100(parser.screen());

--- a/src/render/text.rs
+++ b/src/render/text.rs
@@ -1,12 +1,32 @@
+use crate::daemon::protocol::CursorPos;
+
 /// Format a plain text screenshot for human display.
+///
+/// `mouse_cursor` (when set) is reported as a trailer line *below* the body —
+/// the body itself stays byte-identical to what the inner app drew so regex /
+/// grep over `content` always matches the application's output, never tu's
+/// synthetic overlay.
 pub fn format_screenshot(
     content: &str,
     _rows: u16,
     _cols: u16,
     _cursor_row: u16,
     _cursor_col: u16,
+    mouse_cursor: Option<CursorPos>,
+    mouse_held: bool,
 ) -> String {
-    content.to_string()
+    match mouse_cursor {
+        None => content.to_string(),
+        Some(pos) => {
+            let glyph = if mouse_held { "▲" } else { "△" };
+            let label = if mouse_held { "held " } else { "" };
+            format!(
+                "{content}\n\n{glyph} tu mouse cursor {label}at ({col},{row})",
+                col = pos.col,
+                row = pos.row
+            )
+        }
+    }
 }
 
 /// Format a screenshot as JSON.
@@ -16,6 +36,8 @@ pub fn format_screenshot_json(
     cols: u16,
     cursor_row: u16,
     cursor_col: u16,
+    mouse_cursor: Option<CursorPos>,
+    mouse_held: bool,
 ) -> serde_json::Value {
     serde_json::json!({
         "type": "screenshot",
@@ -26,6 +48,8 @@ pub fn format_screenshot_json(
         "cursor": {
             "row": cursor_row,
             "col": cursor_col,
-        }
+        },
+        "mouse_cursor": mouse_cursor.map(|p| serde_json::json!({"col": p.col, "row": p.row})),
+        "mouse_held": mouse_held,
     })
 }


### PR DESCRIPTION
Closes #15.

## Summary

Started as "add mouse input"; ended as a top-to-bottom emulator overhaul. tu now drives any TUI the same way a human at a real terminal would, with mouse, motion, and the full xterm command set including modern shell-integration sequences.

## What changed

### Mouse input
- `tu mouse click | down | up | move | drag | scroll | state` — full xterm mouse protocol injection.
- `--on-text` / `--on-regex` + `--match-index` — click by content, not coords. Combinable with `--clicks N` for one-shot multi-click on a label.
- `--button left|right|middle`, `--mods Ctrl,Shift,Alt`, `--clicks N`, `--amount N`.
- Auto-encoding (SGR / Default / UTF-8) from the inner app's DECSET state.
- Atomic compound ops — click and drag emit their full sequence in a single PTY write.
- Drag interpolates intermediate cells so apps that track motion (selection drags, panel dividers) see a coherent path.
- Pre-flight gating: out-of-bounds, no-mouse-mode, no-match, conflicting flags all error before any byte goes on the wire. `--force` to bypass.

### Mouse glide (real-mouse motion semantics)
- `click / down / up / move` interpolate motion events from the synthetic cursor's current position to the target, paced ~6 ms/cell, capped at 250 ms total.
- Mouse handler runs **outside the manager lock** so `monitor`'s screenshot polls interleave between glide steps. The synthetic cursor visibly travels; mouse-aware apps see real motion events.
- Wire emission respects the inner app's mouse mode: AnyMotion gets every step, ButtonMotion gets DragMove only when a button is held, weaker modes get nothing on the wire — but the synthetic cursor still glides for the monitor.

### Mouse state introspection
- `tu mouse state` reports mode + encoding + the synthetic cursor tu maintains: position, buttons currently held, last event, terminal size.
- Tracker maintained per-session under the same lock as PTY writes — half-failed compound ops still leave accurate state. Resize-out-of-bounds clears the cursor.

### Synthetic cursor display
- **PNG screenshots**: magenta `△` overlay at the cursor cell — outline when idle, filled magenta cell when held. `--no-cursor` to suppress.
- **Live monitor**: same `△` overlay, baked into the cursor row's frame string so the diff naturally re-emits the row it leaves and the row it enters.
- **Text screenshots**: trailer line below the body (`△ tu mouse cursor at (col,row)`), plus `mouse_cursor` + `mouse_held` keys in JSON. **Body is never spliced** — regex over content stays faithful.

### Live monitor
- 30 fps (was 2 fps). Drag and scroll motion observable in real time.
- Diff-based emission — each frame is rendered to a `Vec<String>` and only changed rows are re-emitted. Idle frames write zero bytes; bandwidth on SSH drops to nothing.
- `needs_clear` discipline on transitions — startup / session switch / error / resize wipes the alt screen before the diff is allowed to make "unchanged" decisions.
- Two dup'd master fds (one for the read loop, one for the writeback path) so they never fight over a single fd handle.

### Emulator: vt100 → alacritty_terminal
- `vt100` silently leaks unhandled escape sequences into cells (OSC 133, OSC 633, APC, etc. rendered as `^[…` artifacts) and never replies to terminal queries — vim / less / mc would hang on startup.
- Switched to [`alacritty_terminal`](https://crates.io/crates/alacritty_terminal). Modern shell-integration sequences are silently consumed. Wide-char rendering uses alacritty's `WIDE_CHAR_SPACER` flag.
- New `CaptureProxy` queues `Event::PtyWrite` from alacritty's `Term` so DA / DCS terminfo / DECRQSS replies get forwarded to the PTY master via the second dup'd fd. Curses apps boot reliably now.
- Mouse mode introspection is bit-accurate from `TermMode::MOUSE_REPORT_CLICK | MOUSE_DRAG | MOUSE_MOTION | SGR_MOUSE | UTF8_MOUSE`.
- `src/emu.rs` isolates the swap; the rest of the codebase keeps the same `Parser` / `Screen` / `Cell` / `Color` shape.

### PTY hygiene
- `ECHOCTL` disabled on spawned PTYs. macOS / Linux / BSD `openpty(3)` defaults set it on; that's what made mc's `^[_` artifact appear (kernel echoing `\x1b` as the printable two-char `^[` for mc to capture). POSIX bit, identical on every platform.

### Docs
- README: refreshed framing, capability list, quick taste, updated architecture diagram.
- CLAUDE.md: file paths now reflect `src/emu.rs`, `src/mouse.rs`, the writeback path, and the lock-release pattern for Wait + Mouse.
- `tu usage`: added MOUSE / MOUSE TARGETING / MOUSE GLIDE / MOUSE CURSOR DISPLAY blocks, plus `--no-cursor` flag.

## Tests + lint

- 75 unit tests (was 22 at branch start). Encoder fixtures, screen-search disambiguation, tracker transitions, OSC 133 / APC silent consumption, DA writeback round-trips, alt-screen reachability, glide path math.
- `cargo fmt --check`, `cargo clippy -- -D warnings`, `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps` all clean.

## Verified

- mc, vim, htop, less, lazygit, tig, tmux-style apps render correctly.
- Mouse drives mc menus, scroll-wheel, drags, F-key footer clicks.
- `tu monitor` is fluid at 30 fps over SSH (tested non-tmux SSH and tmux-wrapped sessions).
- Linux (mc 4.8.30) and macOS (mc HEAD) both render mc's subshell prompt cleanly. The `^[_` artifact you may have seen on macOS earlier was an mc 4.8.33 use-after-free, fixed in mc upstream — independent of tu.

## Test plan

- [x] `cargo test` (75 pass)
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `RUSTDOCFLAGS="-Dwarnings" cargo doc --all-features --no-deps`
- [x] Spawn htop / mc / vim through tu — render correctly, exit cleanly
- [x] `tu mouse click --on-text "OK"` against a real TUI — clicks land, state updates
- [x] Drag (5,5)→(135,40) — visible glide on monitor
- [x] `tu mouse state` reports cursor + buttons_held + last_event + size
- [x] PNG screenshot with and without `--no-cursor`
- [x] Verified on Linux (WSL) — mc renders correctly with clean prompt